### PR TITLE
Parser performance optimizations + Custom delimiters + Layout & Filter caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ openspec
 .idea
 .pub-cache
 .tooling
+
+# Flutter build artifacts
+**/build/
+**/ephemeral/
+**/*.xcconfig
+**/GeneratedPluginRegistrant.*
+**/local.properties

--- a/pkgs/liquify/CHANGELOG.md
+++ b/pkgs/liquify/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 1.5.0
+
+### ⚡ Performance Improvements
+- **92-95% reduction in parser activations** through comprehensive optimization:
+  - Lookahead-based element routing (skips tag parsers for plain text)
+  - Precedence-based expression parser (eliminates repeated prefix parsing)
+  - Pattern-based text(), identifier(), and memberAccess() parsers
+  - First-character routing in primaryTerm() (skips impossible alternatives)
+
+### ⚠️ Breaking Changes
+- **Custom tags using `{{ }}` syntax must now explicitly declare their delimiter type**
+  
+  If you have a custom tag that uses variable-style delimiters (`{{ mytag }}`), you must now override `delimiterType`:
+  
+  ```dart
+  class MyCustomTag with CustomTagParser {
+    @override
+    TagDelimiterType get delimiterType => TagDelimiterType.variable;
+    
+    @override
+    Parser parser() {
+      // ... your parser implementation
+    }
+  }
+  ```
+  
+  Custom tags using standard `{% %}` syntax (the default) require no changes.
+
+### 🔧 Internal Changes
+- Add `TagDelimiterType` enum to distinguish custom tag delimiter styles
+- Optimize parser routing based on delimiter lookahead
+
 ## 1.4.2
  - Bump dependencies
 

--- a/pkgs/liquify/CHANGELOG.md
+++ b/pkgs/liquify/CHANGELOG.md
@@ -1,13 +1,20 @@
 ## 1.5.0
 
-### ⚡ Performance Improvements
+### New Features
+- **Custom delimiters support** - Configure alternative template delimiters via `LiquidConfig`
+  - Use ERB-style (`<% %>`, `<%= %>`), bracket-style (`[% %]`, `[[ ]]`), or any custom delimiters
+  - Built-in presets: `LiquidConfig.erb` for ERB-style templates
+  - Custom tags automatically support configured delimiters via `createTagStart()`, `createTagEnd()`, etc.
+  - Parser caching ensures performance is not impacted when using multiple configurations
+
+### Performance Improvements
 - **92-95% reduction in parser activations** through comprehensive optimization:
   - Lookahead-based element routing (skips tag parsers for plain text)
   - Precedence-based expression parser (eliminates repeated prefix parsing)
   - Pattern-based text(), identifier(), and memberAccess() parsers
   - First-character routing in primaryTerm() (skips impossible alternatives)
 
-### ⚠️ Breaking Changes
+### Breaking Changes
 - **Custom tags using `{{ }}` syntax must now explicitly declare their delimiter type**
   
   If you have a custom tag that uses variable-style delimiters (`{{ mytag }}`), you must now override `delimiterType`:
@@ -26,7 +33,7 @@
   
   Custom tags using standard `{% %}` syntax (the default) require no changes.
 
-### 🔧 Internal Changes
+### Internal Changes
 - Add `TagDelimiterType` enum to distinguish custom tag delimiter styles
 - Optimize parser routing based on delimiter lookahead
 

--- a/pkgs/liquify/README.md
+++ b/pkgs/liquify/README.md
@@ -11,477 +11,254 @@
 [![issues - liquify](https://img.shields.io/github/issues/kingwill101/liquify)](https://github.com/kingwill101/liquify/issues)
 
 
-Liquify is a comprehensive Dart implementation of the Liquid template language, originally created by Shopify. This high-performance library allows you to parse, render, and extend Liquid templates in your Dart and Flutter applications.
+Liquify is a comprehensive Dart implementation of the [Liquid template language](https://shopify.github.io/liquid/), originally created by Shopify. This high-performance library allows you to parse, render, and extend Liquid templates in your Dart and Flutter applications.
 
 ## Features
 
 - Full support for standard Liquid syntax and semantics
 - Synchronous and asynchronous rendering
-- **🔒 Environment-scoped filters and tags** for security and isolation
-- **🛡️ Strict mode** for security sandboxing (blocks global registry access)
-- **⚡ Template-level customization** via environment setup callbacks
-- Extensible architecture for custom tags and filters (both sync and async)
-- High-performance parsing and rendering
-- Strong typing and null safety
-- Comprehensive error handling and reporting
-- Support for complex data structures and nested objects
-- Easy integration with Dart and Flutter projects
-- Extensive set of built-in filters ported from LiquidJS
+- Custom delimiters (ERB-style, bracket-style, or your own)
+- Environment-scoped filters and tags for security isolation
+- Strict mode for security sandboxing
+- Extensible architecture for custom tags and filters
+- Template inheritance with layouts and blocks
 - File system abstraction for template resolution
-- Environment cloning for inheritance patterns
+- High-performance parsing with caching
+- Strong typing and null safety
 
 ## Installation
 
-Add Liquify to your package's `pubspec.yaml` file:
+Add Liquify to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  liquify: ^1.4.1
+  liquify: ^1.5.0
 ```
 
-Or, for the latest development version:
+Then run `dart pub get` or `flutter pub get`.
 
-```yaml
-dependencies:
-  liquify:
-    git: https://github.com/kingwill101/liquify.git
-```
-
-Then run `dart pub get` or `flutter pub get` to install the package.
-
-## Usage
-
-For detailed usage examples, please refer to the [example directory](example) in the repository. Here are some basic usage scenarios:
+## Quick Start
 
 ### Basic Template Rendering
-
-Templates can be rendered both synchronously and asynchronously:
-
-```dart
-import 'package:liquify/liquify.dart';
-
-void main() async {
-  final data = {
-    'name': 'Alice',
-    'items': ['apple', 'banana', 'cherry']
-  };
-
-  final template = Template.parse(
-    'Hello, {{ name | upcase }}! Your items are: {% for item in items %}{{ item }}{% unless forloop.last %}, {% endunless %}{% endfor %}.',
-    data: data
-  );
-  
-  // Synchronous rendering
-  final syncResult = template.render();
-  print(syncResult);
-  // Output: Hello, ALICE! Your items are: apple, banana, cherry.
-
-  // Asynchronous rendering (useful for async filters or includes)
-  final asyncResult = await template.renderAsync();
-  print(asyncResult);
-  // Output: Hello, ALICE! Your items are: apple, banana, cherry.
-}
-```
-
-### Custom render targets
-
-Liquify can render to non-string targets using `renderWith` and a custom `RenderTarget`:
-
-```dart
-final template = Template.parse('Hello {{ name }}!', data: {'name': 'World'});
-final result = template.renderWith(const StringRenderTarget());
-print(result); // Same as render()
-```
-
-You can also update the template context between renders:
-
-```dart
-final template = Template.parse('{{ greeting }} {{ name }}!');
-
-// Update context
-template.updateContext({
-  'greeting': 'Hello',
-  'name': 'World'
-});
-
-print(await template.renderAsync()); // "Hello World!"
-
-// Update context again
-template.updateContext({'greeting': 'Goodbye'});
-print(await template.renderAsync()); // "Goodbye World!"
-```
-
-### Secure Template Rendering with Environment Scoping
-
-For applications requiring security isolation or multi-tenancy:
-
-```dart
-// Create a secure template with custom filters
-final secureTemplate = Template.parse(
-  'Welcome {{ username | sanitize }}! You have {{ messages | size }} messages.',
-  data: {'username': '<script>alert("xss")</script>John', 'messages': ['msg1', 'msg2']},
-  environmentSetup: (env) {
-    // Register only safe, sanitized filters
-    env.registerLocalFilter('sanitize', (value, args, namedArgs) => 
-      value.toString().replaceAll(RegExp(r'[<>]'), ''));
-    env.registerLocalFilter('size', (value, args, namedArgs) => 
-      (value as List).length);
-  },
-);
-
-print(await secureTemplate.renderAsync());
-// Output: Welcome scriptalert("xss")John! You have 2 messages.
-```
-
-### Layout Support
-
-Liquify provides powerful template inheritance through the `layout` tag, allowing you to create reusable base templates and override specific sections using blocks. This feature is particularly useful for maintaining consistent page structures while allowing customization of specific sections.
-
-#### Basic Layout Usage
-
-Here's a simple example of using layouts:
-
-```liquid
-// layouts/base.liquid
-<!DOCTYPE html>
-<html>
-<head>
-  <title>{% block title %}Default Title{% endblock %}</title>
-</head>
-<body>
-  {% block content %}Default content{% endblock %}
-</body>
-</html>
-```
-
-```liquid
-// page.liquid
-{% layout "layouts/base.liquid" %}
-{% block title %}My Page Title{% endblock %}
-{% block content %}
-  <h1>Welcome to my page!</h1>
-  <p>This is custom content.</p>
-{% endblock %}
-```
-
-#### Passing Variables to Layouts
-
-You can pass variables from your template to the layout:
-
-```liquid
-{% assign page_title = "Welcome" %}
-{% layout "layouts/base.liquid", title: page_title, year: 2024 %}
-```
-
-#### Multiple Named Blocks
-
-Layouts can define multiple named blocks that can be selectively overridden:
-
-```liquid
-// layouts/post.liquid
-{% layout "layouts/base.liquid" %}
-
-{% block meta %}
-  <meta name="author" content="{{ post.author }}">
-{% endblock %}
-
-{% block content %}
-  <article>
-    <h1>{{ post.title }}</h1>
-    {% block post_content %}{% endblock %}
-  </article>
-{% endblock %}
-```
-
-```liquid
-// blog-post.liquid
-{% layout "layouts/post.liquid", post: post %}
-{% block post_content %}
-  {{ post.body }}
-{% endblock %}
-```
-
-#### Default Block Contents
-
-Blocks in layouts can include default content that will be used if not overridden:
-
-```liquid
-{% block footer %}
-  <footer>&copy; {{ year }} Default Footer</footer>
-{% endblock %}
-```
-
-For more complex layout examples and advanced usage, please refer to the [example directory](example) in the repository.
-
-### File System and Template Resolution
-
-Liquify provides flexible ways to resolve and load templates from various sources. The `Root` class is the base for implementing template resolution strategies.
-
-#### Using MapRoot for In-Memory Templates
-
-`MapRoot` is a simple implementation of `Root` that stores templates in memory:
 
 ```dart
 import 'package:liquify/liquify.dart';
 
 void main() {
-  final fs = MapRoot({
-    'resume.liquid': '''
-Name: {{ name }}
-Skills: {{ skills | join: ", " }}
-{% render 'greeting.liquid' with name: name, greeting: "Welcome" %}
-''',
-    'greeting.liquid': '{{ greeting }}, {{ name }}!',
-  });
-
-  final context = {
-    'name': 'Alice Johnson',
-    'skills': ['Dart', 'Flutter', 'Liquid'],
-  };
-
-  final template = Template.fromFile('resume.liquid', fs, data: context);
-  print(template.render());
+  final template = Template.parse(
+    'Hello, {{ name | upcase }}!',
+    data: {'name': 'world'},
+  );
+  
+  print(template.render()); // Output: Hello, WORLD!
 }
 ```
 
-#### Custom Template Resolution
+### Using the Liquid Class
 
-For more complex scenarios, such as loading templates from a file system or a database, you can create a custom subclass of `Root`:
+The `Liquid` class provides a convenient API, especially when using custom delimiters:
 
 ```dart
-class FileSystemRoot extends Root {
-  final String basePath;
+final liquid = Liquid();
+final result = liquid.renderString('Hello, {{ name }}!', {'name': 'World'});
+print(result); // Output: Hello, World!
+```
 
-  FileSystemRoot(this.basePath);
-  
-  @override
-  String? resolve(String path) {
-    final file = File('$basePath/$path');
-    if (file.existsSync()) {
-      return file.readAsStringSync();
-    }
-    return null;
-  }
-}
+### Async Rendering
 
-void main() async {
-  final fs = FileSystemRoot('/path/to/templates');
-  final template = Template.fromFile('resume.liquid', fs, data: context);
-  
-  // Sync rendering
-  print(template.render());
-  
-  // Async rendering (recommended for templates with includes or async filters)
-  print(await template.renderAsync());
-}
+Use async rendering for templates with async filters or includes:
 
-// Example with async template resolution
-class AsyncFileSystemRoot extends Root {
-  final String basePath;
+```dart
+final result = await template.renderAsync();
+```
 
-  AsyncFileSystemRoot(this.basePath);
-  
+## Custom Delimiters
+
+Liquify supports custom delimiters for integrating with other template systems or avoiding conflicts with frontend frameworks.
+
+### ERB-Style Delimiters
+
+```dart
+final liquid = Liquid(config: LiquidConfig.erb);
+final result = liquid.renderString(
+  '<% if show %>Hello, <%= name %>!<% endif %>',
+  {'show': true, 'name': 'World'},
+);
+print(result); // Output: Hello, World!
+```
+
+### Custom Delimiters
+
+```dart
+final liquid = Liquid.withDelimiters(
+  tagStart: '[%',
+  tagEnd: '%]',
+  varStart: '[[',
+  varEnd: ']]',
+);
+
+final result = liquid.renderString(
+  '[% for item in items %][[ item ]] [% endfor %]',
+  {'items': ['a', 'b', 'c']},
+);
+print(result); // Output: a b c
+```
+
+### Whitespace Control
+
+Whitespace stripping works with custom delimiters using the `-` marker:
+
+```dart
+final liquid = Liquid.withDelimiters(tagStart: '[%', tagEnd: '%]', varStart: '[[', varEnd: ']]');
+
+final result = liquid.renderString('Hello    [[- name ]]!', {'name': 'World'});
+print(result); // Output: HelloWorld!
+```
+
+## Template Inheritance
+
+Liquify supports template inheritance through the `layout` tag:
+
+```liquid
+<!-- layouts/base.liquid -->
+<!DOCTYPE html>
+<html>
+<head><title>{% block title %}Default{% endblock %}</title></head>
+<body>{% block content %}{% endblock %}</body>
+</html>
+```
+
+```liquid
+<!-- page.liquid -->
+{% layout "layouts/base.liquid" %}
+{% block title %}My Page{% endblock %}
+{% block content %}<h1>Welcome!</h1>{% endblock %}
+```
+
+Variables can be passed to layouts:
+
+```liquid
+{% layout "layouts/base.liquid", title: page_title, year: 2024 %}
+```
+
+## File System and Template Resolution
+
+### In-Memory Templates with MapRoot
+
+```dart
+final fs = MapRoot({
+  'main.liquid': 'Hello {% render "partial.liquid" %}',
+  'partial.liquid': 'World!',
+});
+
+final template = Template.fromFile('main.liquid', fs);
+print(template.render()); // Output: Hello World!
+```
+
+### Custom Template Resolution
+
+Implement the `Root` class for custom template sources:
+
+```dart
+class DatabaseRoot extends Root {
   @override
   Future<String?> resolveAsync(String path) async {
-    final file = File('$basePath/$path');
-    if (await file.exists()) {
-      return await file.readAsString();
-    }
-    return null;
+    return await database.getTemplate(path);
   }
 }
 ```
 
-The async support is particularly useful when:
-- Loading templates from remote sources
-- Using async filters or tags
-- Processing large templates with many includes
-- Implementing database-backed template storage
+## Security and Isolation
 
-This approach allows you to implement custom logic for resolving and loading templates from any source, such as a file system, database, or network resource.
+### Environment-Scoped Filters
 
-The `render` tag uses this resolution mechanism to include and render other templates, allowing for modular and reusable template structures.
-
-### Environment-Scoped Registry (Advanced Security & Isolation)
-
-Liquify provides powerful environment-scoped filters and tags that allow you to create isolated template execution contexts. This feature is particularly useful for multi-tenant applications, security sandboxing, and plugin systems.
-
-#### Basic Environment Usage
+Register filters that are isolated to a specific template:
 
 ```dart
-import 'package:liquify/liquify.dart';
+final template = Template.parse(
+  '{{ input | sanitize }}',
+  data: {'input': '<script>alert("xss")</script>'},
+  environmentSetup: (env) {
+    env.registerLocalFilter('sanitize', (value, args, namedArgs) => 
+      value.toString().replaceAll(RegExp(r'<[^>]*>'), ''));
+  },
+);
 
-void main() async {
-  // Template with environment setup callback
-  final template = Template.parse(
-    'Hello {{ name | emphasize }}! {% custom_greeting %}',
-    data: {'name': 'World'},
-    environmentSetup: (env) {
-      // Register custom filters and tags for this template only
-      env.registerLocalFilter('emphasize', (value, args, namedArgs) => 
-        '***${value.toString().toUpperCase()}***');
-      env.registerLocalTag('custom_greeting', (content, filters) => 
-        CustomGreetingTag(content, filters));
-    },
-  );
-
-  print(await template.renderAsync());
-  // Output: Hello ***WORLD***! 🎉 Welcome! 🎉
-}
+print(template.render()); // Output: alert("xss")
 ```
 
-#### Security Sandboxing with Strict Mode
+### Strict Mode
+
+Block access to global filters and tags for untrusted content:
 
 ```dart
-void main() async {
-  // Create a secure environment that blocks global registry access
-  final secureEnv = Environment.withStrictMode();
-  
-  // Only register safe, sanitized filters
-  secureEnv.registerLocalFilter('sanitize', (value, args, namedArgs) {
-    return value.toString()
-      .replaceAll(RegExp(r'<[^>]*>'), '') // Remove HTML tags
-      .replaceAll(RegExp(r'[<>"\']'), ''); // Remove dangerous characters
-  });
-  
-  secureEnv.registerLocalFilter('truncate', (value, args, namedArgs) {
-    final maxLen = args.isNotEmpty ? args[0] as int : 50;
-    final str = value.toString();
-    return str.length > maxLen ? '${str.substring(0, maxLen)}...' : str;
-  });
+final secureEnv = Environment.withStrictMode();
+secureEnv.registerLocalFilter('safe_filter', myFilter);
 
-  final secureTemplate = Template.parse(
-    'Safe content: {{ userInput | sanitize | truncate: 20 }}',
-    data: {'userInput': '<script>alert("XSS")</script>This is user input'},
-    environment: secureEnv,
-  );
-
-  print(await secureTemplate.renderAsync());
-  // Output: Safe content: scriptalert("XSS")Th...
-  
-  // Attempting to use global filters will return null in strict mode
-  print(secureEnv.getFilter('dangerous_global_filter')); // null
-}
+final template = Template.parse(source, environment: secureEnv);
 ```
 
-#### Environment Isolation Between Templates
+### Environment Cloning
+
+Create child environments that inherit from a parent:
 
 ```dart
-void main() async {
-  // Template A with specific formatting
-  final templateA = Template.parse(
-    'Result: {{ value | format }}',
-    data: {'value': 'test'},
-    environmentSetup: (env) {
-      env.registerLocalFilter('format', (value, args, namedArgs) => 
-        'TEMPLATE_A_FORMAT:$value');
-    },
-  );
+final baseEnv = Environment();
+baseEnv.registerLocalFilter('base', baseFilter);
 
-  // Template B with different formatting
-  final templateB = Template.parse(
-    'Result: {{ value | format }}',
-    data: {'value': 'test'},
-    environmentSetup: (env) {
-      env.registerLocalFilter('format', (value, args, namedArgs) => 
-        'TEMPLATE_B_FORMAT:$value');
-    },
-  );
-
-  print(await templateA.renderAsync()); // Result: TEMPLATE_A_FORMAT:test
-  print(await templateB.renderAsync()); // Result: TEMPLATE_B_FORMAT:test
-}
+final childEnv = baseEnv.clone();
+childEnv.registerLocalFilter('child', childFilter);
+// childEnv has access to both 'base' and 'child' filters
 ```
 
-#### Environment Cloning and Inheritance
+## Custom Tags and Filters
+
+### Custom Filter
 
 ```dart
-void main() async {
-  // Create a base environment with common filters
-  final baseEnv = Environment();
-  baseEnv.registerLocalFilter('base_format', (value, args, namedArgs) => 
-    'BASE:$value');
-  baseEnv.registerLocalTag('base_tag', (content, filters) => 
-    BaseTag(content, filters));
+FilterRegistry.register('reverse_words', (value, args, namedArgs) {
+  return value.toString().split(' ').reversed.join(' ');
+});
 
-  // Clone and extend for specific use cases
-  final childEnv = baseEnv.clone();
-  childEnv.registerLocalFilter('child_format', (value, args, namedArgs) => 
-    'CHILD:$value');
-  childEnv.registerLocalTag('child_tag', (content, filters) => 
-    ChildTag(content, filters));
-
-  final template = Template.parse(
-    '''
-    Base: {{ text | base_format }}
-    Child: {{ text | child_format }}
-    {% base_tag %}{% child_tag %}
-    ''',
-    data: {'text': 'test'},
-    environment: childEnv,
-  );
-
-  print(await template.renderAsync());
-  // Output:
-  // Base: BASE:test
-  // Child: CHILD:test
-  // [BASE_TAG][CHILD_TAG]
-}
+// Usage: {{ "hello world" | reverse_words }} -> "world hello"
 ```
 
-#### Dynamic Environment Modification
+### Custom Tag
 
 ```dart
-void main() async {
-  final template = Template.parse(
-    'Filtered: {{ message | transform }}',
-    data: {'message': 'hello'},
-  );
+class ShoutTag extends AbstractTag with CustomTagParser {
+  ShoutTag(super.content, super.filters);
 
-  // Register initial filter
-  template.environment.registerLocalFilter('transform', (value, args, namedArgs) => 
-    'INITIAL:$value');
+  @override
+  dynamic evaluateWithContext(Evaluator evaluator, Buffer buffer) {
+    final text = evaluator.evaluate(content.first)?.toString() ?? '';
+    buffer.write(text.toUpperCase());
+  }
 
-  print(await template.renderAsync()); // Filtered: INITIAL:hello
-
-  // Dynamically change the filter behavior
-  template.environment.registerLocalFilter('transform', (value, args, namedArgs) => 
-    'UPDATED:$value');
-
-  print(await template.renderAsync()); // Filtered: UPDATED:hello
+  @override
+  Parser parser([LiquidConfig? config]) {
+    return (createTagStart(config) &
+            string('shout').trim() &
+            ref0(expression).trim() &
+            createTagEnd(config))
+        .map((values) => Tag('shout', [values[2] as ASTNode]));
+  }
 }
+
+TagRegistry.register('shout', (content, filters) => ShoutTag(content, filters));
+
+// Usage: {% shout "hello" %} -> HELLO
 ```
 
-#### Use Cases for Environment-Scoped Registry
-
-1. **Multi-tenant Applications**: Each tenant gets their own isolated environment
-2. **Security Sandboxing**: Restrict template capabilities for untrusted content
-3. **Plugin Systems**: Plugins can register their own filters/tags without conflicts
-4. **API Versioning**: Different API versions with different template capabilities
-5. **Theme Systems**: Different themes with custom visual filters
-6. **Content Management**: Different content types with specialized processing
-
-#### Priority System
-
-The environment-scoped registry follows a clear priority system:
-
-1. **Local filters/tags** (registered via `registerLocalFilter`/`registerLocalTag`)
-2. **Global filters/tags** (registered via `FilterRegistry.register`/`TagRegistry.register`)
-3. **Strict mode** blocks access to global registries entirely
-
-This ensures predictable behavior while maintaining flexibility.
-
-### Custom Tags and Filters
-
-Liquify allows you to create custom tags and filters. For detailed examples, please refer to the [example directory](example) in the repository.
+For more examples, see the [example directory](example).
 
 ## API Documentation
 
-Detailed API documentation is available [here](https://pub.dev/documentation/liquify/latest/).
+Full API documentation is available at [pub.dev](https://pub.dev/documentation/liquify/latest/).
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+Contributions are welcome! Please open an issue first for major changes.
 
 ## License
 
@@ -489,14 +266,6 @@ This project is licensed under the [MIT License](LICENSE).
 
 ## Acknowledgements
 
-- Shopify for the original Liquid template language
-- The Dart team for the excellent language and tools
-- [LiquidJS](https://github.com/harttle/liquidjs) for their comprehensive set of filters, which we've ported to Dart
-- [liquid_dart](https://github.com/ergonlabs/liquid_dart) for their initial Dart implementation, which served as inspiration for this project
-
-## Related Projects
-
-- [LiquidJS](https://github.com/harttle/liquidjs): A popular JavaScript implementation of Liquid templates
-- [liquid_dart](https://github.com/ergonlabs/liquid_dart): An earlier Dart implementation of Liquid templates (now unmaintained)
-
-Liquify aims to provide a modern, maintained, and feature-rich Liquid template engine for the Dart ecosystem, building upon the work of these excellent projects.
+- [Shopify](https://shopify.github.io/liquid/) for the original Liquid template language
+- [LiquidJS](https://github.com/harttle/liquidjs) for their comprehensive filter implementations
+- [liquid_dart](https://github.com/ergonlabs/liquid_dart) for initial Dart implementation inspiration

--- a/pkgs/liquify/example/custom_delimiters.dart
+++ b/pkgs/liquify/example/custom_delimiters.dart
@@ -1,0 +1,202 @@
+// Example demonstrating custom delimiters in Liquify.
+//
+// This example shows how to use the [Liquid] class with custom delimiters
+// for parsing and rendering Liquid templates.
+import 'package:liquify/liquify.dart';
+
+void main() {
+  // Basic usage with default delimiters
+  defaultDelimitersExample();
+
+  // Custom delimiters
+  customDelimitersExample();
+
+  // ERB-style delimiters
+  erbDelimitersExample();
+
+  // Whitespace control
+  whitespaceControlExample();
+
+  // Multiple Liquid instances
+  multipleInstancesExample();
+
+  // One-shot rendering
+  oneShotRenderingExample();
+}
+
+/// Using default Liquid delimiters ({% %} and {{ }})
+void defaultDelimitersExample() {
+  print('\n--- Default Delimiters ---');
+
+  final liquid = Liquid();
+  final template = liquid.parse('Hello {{ name }}!');
+  final result = template.render({'name': 'World'});
+
+  print(result);
+  // Output: Hello World!
+}
+
+/// Using custom delimiters ([% %] and [[ ]])
+void customDelimitersExample() {
+  print('\n--- Custom Delimiters ---');
+
+  final liquid = Liquid(
+    config: LiquidConfig(
+      tagStart: '[%',
+      tagEnd: '%]',
+      varStart: '[[',
+      varEnd: ']]',
+    ),
+  );
+
+  // Block tags work with custom delimiters
+  final template = liquid.parse('''
+[% if show %]
+  Hello [[ name ]]!
+[% endif %]
+''');
+
+  final result = template.render({'show': true, 'name': 'Alice'});
+  print(result);
+  // Output:
+  //   Hello Alice!
+
+  // For loops also work
+  final forTemplate = liquid.parse('''
+[% for item in items %]
+  - [[ item ]]
+[% endfor %]
+''');
+
+  final forResult = forTemplate.render({
+    'items': ['apple', 'banana', 'cherry'],
+  });
+  print(forResult);
+  // Output:
+  //   - apple
+  //   - banana
+  //   - cherry
+}
+
+/// Using ERB-style delimiters (<% %> and <%= %>)
+void erbDelimitersExample() {
+  print('\n--- ERB-Style Delimiters ---');
+
+  // Using the ERB preset
+  final liquid = Liquid(config: LiquidConfig.erb);
+
+  final template = liquid.parse('''
+<% if user %>
+  Hello <%= user.name %>!
+<% else %>
+  Hello Guest!
+<% endif %>
+''');
+
+  final result = template.render({
+    'user': {'name': 'Bob'},
+  });
+  print(result);
+  // Output:
+  //   Hello Bob!
+
+  // Alternative: use the convenience constructor
+  final liquid2 = Liquid.withDelimiters(
+    tagStart: '<%',
+    tagEnd: '%>',
+    varStart: '<%=',
+    varEnd: '%>',
+  );
+  print(liquid2.renderString('<%= greeting %>', {'greeting': 'Hi there!'}));
+  // Output: Hi there!
+}
+
+/// Whitespace control with custom delimiters
+void whitespaceControlExample() {
+  print('\n--- Whitespace Control ---');
+
+  final liquid = Liquid(
+    config: LiquidConfig(
+      tagStart: '[%',
+      tagEnd: '%]',
+      varStart: '[[',
+      varEnd: ']]',
+      stripMarker: '-', // default
+    ),
+  );
+
+  // Using strip markers to control whitespace
+  final template = liquid.parse('''
+Items:
+[%- for item in items -%]
+[[ item ]]
+[%- endfor -%]
+Done!''');
+
+  final result = template.render({
+    'items': ['a', 'b', 'c'],
+  });
+  print(result);
+  // Output: Items:
+  // a
+  // b
+  // c
+  // Done!
+}
+
+/// Using multiple Liquid instances with different configurations
+void multipleInstancesExample() {
+  print('\n--- Multiple Instances ---');
+
+  // Standard Liquid
+  final standard = Liquid();
+
+  // ERB-style
+  final erb = Liquid(config: LiquidConfig.erb);
+
+  // Custom brackets
+  final brackets = Liquid.withDelimiters(
+    tagStart: '<<',
+    tagEnd: '>>',
+    varStart: '<<<',
+    varEnd: '>>>',
+  );
+
+  // Parse with different syntaxes
+  final t1 = standard.parse('Hello {{ name }}!');
+  final t2 = erb.parse('Hello <%= name %>!');
+  final t3 = brackets.parse('Hello <<< name >>>!');
+
+  final data = {'name': 'World'};
+
+  print('Standard: ${t1.render(data)}');
+  print('ERB:      ${t2.render(data)}');
+  print('Brackets: ${t3.render(data)}');
+  // Output:
+  // Standard: Hello World!
+  // ERB:      Hello World!
+  // Brackets: Hello World!
+}
+
+/// One-shot rendering without storing the template
+void oneShotRenderingExample() {
+  print('\n--- One-Shot Rendering ---');
+
+  final liquid = Liquid(
+    config: LiquidConfig(
+      tagStart: '[%',
+      tagEnd: '%]',
+      varStart: '[[',
+      varEnd: ']]',
+    ),
+  );
+
+  // For templates used only once, use renderString
+  final result = liquid.renderString(
+    '[% if active %]Status: [[ status ]][% endif %]',
+    {'active': true, 'status': 'Online'},
+  );
+
+  print(result);
+  // Output: Status: Online
+}

--- a/pkgs/liquify/example/custom_tag.dart
+++ b/pkgs/liquify/example/custom_tag.dart
@@ -2,9 +2,7 @@ import 'package:liquify/liquify.dart';
 import 'package:liquify/parser.dart';
 
 void main() {
-  print('Custom Box Tag Example\n');
-
-  // Register the custom tag
+  // Register the custom tag (works with any delimiters)
   TagRegistry.register('box', (content, filters) => BoxTag(content, filters));
   FilterRegistry.register('sum', (value, args, namedArgs) {
     if (value is! List) {
@@ -13,39 +11,85 @@ void main() {
     return (value as List<int>).reduce((int a, int b) => a + b);
   });
 
-  // Define the template
+  // Example 1: Standard delimiters
+  standardDelimitersExample();
+
+  // Example 2: Custom delimiters with custom tags
+  customDelimitersExample();
+
+  // Example 3: ERB-style delimiters with custom tags
+  erbDelimitersExample();
+}
+
+/// Custom tag with standard Liquid delimiters ({% %})
+void standardDelimitersExample() {
+  print('=== Standard Delimiters ===\n');
+
   final template = '''
-Default box:
 {% box %}
 Hello, World!
 This is a custom box tag.
 {% endbox %}
 
-Custom character box:
 {% box * %}
 Using a custom box character.
-Multiple lines are supported.
 {% endbox %}
+''';
 
-Box with calculations:
-{% box %}
-Total: {{ items | size }}
-Sum: {% for item in items %} {{ item }} {% unless forloop.last %} + {% endunless %}{% endfor %} = {{ items | sum }}
-{% endbox %}
-  ''';
-
-  // Create a context with some variables
-  final context = {
-    'name': 'Alice',
-    'age': 30,
-    'items': [1, 2, 3, 4, 5],
-  };
-
-  // Parse and render the template
-  final result = Template.parse(template, data: context);
-
-  // Print the result
+  final result = Template.parse(
+    template,
+    data: {
+      'items': [1, 2, 3],
+    },
+  );
   print(result.render());
+}
+
+/// Custom tag with custom delimiters ([% %])
+void customDelimitersExample() {
+  print('\n=== Custom Delimiters ([% %]) ===\n');
+
+  // Create a Liquid instance with custom delimiters
+  final liquid = Liquid(
+    config: LiquidConfig(
+      tagStart: '[%',
+      tagEnd: '%]',
+      varStart: '[[',
+      varEnd: ']]',
+    ),
+  );
+
+  // The custom tag automatically works with the custom delimiters
+  // because BoxTag.parser() uses createTagStart/createTagEnd
+  final template = liquid.parse('''
+[% box %]
+Custom delimiters work!
+Value: [[ name ]]
+[% endbox %]
+
+[% box # %]
+Different box character.
+[% endbox %]
+''');
+
+  print(template.render({'name': 'Alice'}));
+}
+
+/// Custom tag with ERB-style delimiters (<% %>)
+void erbDelimitersExample() {
+  print('\n=== ERB-Style Delimiters (<% %>) ===\n');
+
+  // Use the ERB preset
+  final liquid = Liquid(config: LiquidConfig.erb);
+
+  final template = liquid.parse('''
+<% box %>
+ERB-style delimiters!
+User: <%= user %>
+<% endbox %>
+''');
+
+  print(template.render({'user': 'Bob'}));
 }
 
 class BoxTag extends AbstractTag with CustomTagParser {
@@ -55,7 +99,10 @@ class BoxTag extends AbstractTag with CustomTagParser {
   dynamic evaluate(Evaluator evaluator, Buffer buffer) {
     String content = evaluator.evaluate(body[0]).toString().trim();
 
-    content = Template.parse(content, data: evaluator.context.all()).render();
+    // Use the config from the environment to re-parse with the same delimiters
+    final config = evaluator.context.config;
+    final liquid = Liquid(config: config ?? LiquidConfig.standard);
+    content = liquid.renderString(content, evaluator.context.all());
 
     String boxChar = this.content.isNotEmpty
         ? evaluator.evaluate(this.content[0]).toString()
@@ -77,17 +124,17 @@ class BoxTag extends AbstractTag with CustomTagParser {
   }
 
   @override
-  Parser parser() {
-    return (tagStart() &
+  Parser parser([LiquidConfig? config]) {
+    final start = createTagStart(config);
+    final end = createTagEnd(config);
+    return (start &
             string('box').trim() &
-            any().starLazy(tagEnd()).flatten().optional() &
-            tagEnd() &
-            any()
-                .starLazy(tagStart() & string('endbox').trim() & tagEnd())
-                .flatten() &
-            tagStart() &
+            any().starLazy(end).flatten().optional() &
+            end &
+            any().starLazy(start & string('endbox').trim() & end).flatten() &
+            start &
             string('endbox').trim() &
-            tagEnd())
+            end)
         .map((values) {
           var boxChar = values[2] != null ? TextNode(values[2]) : null;
           return Tag(

--- a/pkgs/liquify/example/example.dart
+++ b/pkgs/liquify/example/example.dart
@@ -77,16 +77,18 @@ class ReverseTag extends AbstractTag with CustomTagParser {
   }
 
   @override
-  Parser parser() {
-    return (tagStart() &
+  Parser parser([LiquidConfig? config]) {
+    final start = createTagStart(config);
+    final end = createTagEnd(config);
+    return (start &
             string('reverse').trim() &
-            tagEnd() &
+            end &
             any()
-                .starLazy(tagStart() & string('endreverse').trim() & tagEnd())
+                .starLazy(start & string('endreverse').trim() & end)
                 .flatten() &
-            tagStart() &
+            start &
             string('endreverse').trim() &
-            tagEnd())
+            end)
         .map((values) {
           return Tag("reverse", [TextNode(values[3])]);
         });

--- a/pkgs/liquify/lib/liquify.dart
+++ b/pkgs/liquify/lib/liquify.dart
@@ -187,6 +187,44 @@
 /// - Full Liquid syntax support including control flow and iteration
 /// - Drop interface for custom object behavior
 /// - Environment cloning for inheritance patterns
+/// - **Custom delimiters** for non-standard Liquid syntax
+///
+/// ## Custom Delimiters
+///
+/// Use the [Liquid] class for custom delimiter support:
+///
+/// ```dart
+/// // Standard delimiters (default)
+/// final liquid = Liquid();
+/// final template = liquid.parse('Hello {{ name }}!');
+/// final result = template.render({'name': 'World'});
+/// print(result); // Hello World!
+///
+/// // Custom delimiters
+/// final custom = Liquid(
+///   config: LiquidConfig(
+///     tagStart: '[%',
+///     tagEnd: '%]',
+///     varStart: '[[',
+///     varEnd: ']]',
+///   ),
+/// );
+/// final tpl = custom.parse('[% if show %]Hello [[ name ]]![% endif %]');
+/// print(tpl.render({'show': true, 'name': 'Alice'})); // Hello Alice!
+///
+/// // Convenience constructor
+/// final erb = Liquid.withDelimiters(
+///   tagStart: '<%',
+///   tagEnd: '%>',
+///   varStart: '<%=',
+///   varEnd: '%>',
+/// );
+///
+/// // ERB preset
+/// final erbLiquid = Liquid(config: LiquidConfig.erb);
+/// ```
+///
+/// See [Liquid], [LiquidConfig], and [LiquidTemplate] for full documentation.
 ///
 /// For detailed API documentation, see the individual class and function
 /// documentation.
@@ -201,3 +239,5 @@ export 'package:liquify/src/tag_registry.dart';
 export 'package:liquify/src/filter_registry.dart';
 export 'package:liquify/src/filters/module.dart';
 export 'package:liquify/src/render_target.dart';
+export 'package:liquify/src/config.dart';
+export 'package:liquify/src/liquid.dart';

--- a/pkgs/liquify/lib/parser.dart
+++ b/pkgs/liquify/lib/parser.dart
@@ -7,6 +7,9 @@
 ///
 /// 1. Parsing and Grammar (in `src/grammar/shared.dart`):
 ///    - Basic Liquid syntax parsers: [tagStart], [tagEnd], [varStart], [varEnd]
+///    - Configurable delimiter factories: [createTagStart], [createTagEnd],
+///      [createVarStart], [createVarEnd] - use these with [LiquidConfig] for
+///      custom delimiters
 ///    - Expression parsers: [expression], [literal], [identifier], [memberAccess]
 ///    - Tag helpers: [someTag], [breakTag], [continueTag], [elseTag]
 ///    - Main parsing function: [parseInput]
@@ -53,17 +56,20 @@
 ///   }
 ///
 ///   @override
-///   Parser parser() {
+///   Parser parser([LiquidConfig? config]) {
 ///     // Custom parser implementation for tags with end tags
-///     return (tagStart() &
+///     // Use createTagStart/createTagEnd to support custom delimiters
+///     final start = createTagStart(config);
+///     final end = createTagEnd(config);
+///     return (start &
 ///             string('uppercase').trim() &
-///             tagEnd() &
+///             end &
 ///             any()
-///                 .starLazy(tagStart() & string('enduppercase').trim() & tagEnd())
+///                 .starLazy(start & string('enduppercase').trim() & end)
 ///                 .flatten() &
-///             tagStart() &
+///             start &
 ///             string('enduppercase').trim() &
-///             tagEnd())
+///             end)
 ///         .map((values) {
 ///       return Tag("uppercase", [TextNode(values[3])]);
 ///     });
@@ -71,7 +77,11 @@
 /// }
 ///
 /// // For a simple tag without an end tag, you could use someTag:
-/// // Parser simpleParser() => someTag('simpletag');
+/// // Parser simpleParser([LiquidConfig? config]) => someTag('simpletag', config: config);
+///
+/// // For custom delimiters, use someTag with a config:
+/// // final config = LiquidConfig(tagStart: '[%', tagEnd: '%]');
+/// // Parser customParser([LiquidConfig? config]) => someTag('mytag', config: config);
 ///
 /// // Register the custom tag
 /// TagRegistry.register('uppercase', (content, filters) => UppercaseTag(content, filters));
@@ -93,3 +103,4 @@ library;
 export 'package:liquify/src/tag.dart';
 export 'package:liquify/src/tag_registry.dart';
 export 'package:liquify/src/context.dart';
+export 'package:liquify/src/config.dart';

--- a/pkgs/liquify/lib/src/analyzer/block_info.dart
+++ b/pkgs/liquify/lib/src/analyzer/block_info.dart
@@ -140,20 +140,27 @@ class BlockInfo {
     };
   }
 
-  /// Creates a deep copy of this block with a new source template.
+  /// Creates a copy of this block for use in a child template.
   ///
-  /// This method creates a completely new instance of BlockInfo and all its
-  /// nested blocks, with the new source template path. This is useful when
-  /// copying blocks between templates.
+  /// This method creates a new BlockInfo that represents this block being
+  /// inherited by a child template. The copy:
+  /// * Has `isOverride: false` because it's the inherited version, not an override
+  /// * Has `parent` pointing to this block (the original)
+  /// * Preserves hasSuperCall status
+  /// * Recursively copies nested blocks
+  ///
+  /// Note: This is NOT a true deep copy - it's specifically for template
+  /// inheritance scenarios. For a true copy that preserves all properties,
+  /// use [copyWith].
   ///
   /// Parameters:
   /// * [newSource] - The new template path to use as the source
   ///
-  /// Returns a new [BlockInfo] instance with all nested blocks copied.
+  /// Returns a new [BlockInfo] representing this block as inherited.
   ///
   /// Example:
   /// ```dart
-  /// final copiedBlock = originalBlock.deepCopy('new_template.liquid');
+  /// final inheritedBlock = parentBlock.deepCopy('child_template.liquid');
   /// ```
   BlockInfo deepCopy(String newSource) {
     final nestedBlocksCopy = <String, BlockInfo>{};

--- a/pkgs/liquify/lib/src/analyzer/resolver.dart
+++ b/pkgs/liquify/lib/src/analyzer/resolver.dart
@@ -310,26 +310,23 @@ Map<String, String> _getOrBuildNestedLookup(Map<String, BlockInfo> overrides) {
 
 List<ASTNode> _collapseNodes(List<ASTNode> nodes) {
   List<ASTNode> result = [];
-  TextNode? currentText;
+  StringBuffer? textBuffer;
 
   for (var node in nodes) {
     if (node is TextNode) {
-      if (currentText == null) {
-        currentText = node;
-      } else {
-        currentText = TextNode(currentText.text + node.text);
-      }
+      textBuffer ??= StringBuffer();
+      textBuffer.write(node.text);
     } else {
-      if (currentText != null) {
-        result.add(currentText);
-        currentText = null;
+      if (textBuffer != null) {
+        result.add(TextNode(textBuffer.toString()));
+        textBuffer = null;
       }
       result.add(node);
     }
   }
 
-  if (currentText != null) {
-    result.add(currentText);
+  if (textBuffer != null) {
+    result.add(TextNode(textBuffer.toString()));
   }
 
   return result;

--- a/pkgs/liquify/lib/src/analyzer/resolver.dart
+++ b/pkgs/liquify/lib/src/analyzer/resolver.dart
@@ -5,10 +5,6 @@ import 'package:liquify/src/util.dart';
 
 final resolverLogger = Logger('Resolver');
 
-/// Cache for nested block name lookups.
-/// Maps simple block names to their full qualified names.
-final _nestedBlockNameCache = Expando<Map<String, String>>('nestedBlockNames');
-
 /// Cache the last overrides map we built a lookup for.
 /// This allows reuse within a single buildCompleteMergedAst call.
 Map<String, BlockInfo>? _lastOverridesMap;

--- a/pkgs/liquify/lib/src/analyzer/template_analyzer.dart
+++ b/pkgs/liquify/lib/src/analyzer/template_analyzer.dart
@@ -31,12 +31,38 @@ class TemplateAnalyzer {
   /// Logger instance for debugging and tracing template analysis.
   final Logger logger = Logger('TemplateAnalyzer');
 
+  /// Cache of already-analyzed template structures.
+  /// Key is the template path, value is the analyzed structure.
+  final Map<String, TemplateStructure> _structureCache = {};
+
+  /// Cache of parsed AST nodes for templates.
+  /// Key is the template path, value is the parsed nodes.
+  final Map<String, List<ASTNode>> _parseCache = {};
+
   /// Creates a new template analyzer with an optional root directory context.
   ///
   /// The [root] parameter provides the context for resolving template paths and
   /// reading template content. If not provided, the analyzer can only work with
   /// explicitly provided template content through [initialNodes].
   TemplateAnalyzer([this.root]);
+
+  /// Clears all cached analysis results.
+  ///
+  /// Call this when template files have been modified and need re-analysis.
+  void clearCache() {
+    _structureCache.clear();
+    _parseCache.clear();
+  }
+
+  /// Clears cached analysis for a specific template.
+  ///
+  /// Also clears cache for any templates that depend on it (children).
+  void invalidateTemplate(String templatePath) {
+    _structureCache.remove(templatePath);
+    _parseCache.remove(templatePath);
+    // Note: We don't track dependencies, so we can't invalidate children
+    // For full invalidation, use clearCache()
+  }
 
   /// Analyzes a template and yields analysis results as they become available.
   ///
@@ -130,22 +156,40 @@ class TemplateAnalyzer {
         if (node.content.isNotEmpty && node.content.first is Literal) {
           final parentPath = (node.content.first as Literal).value.toString();
           logger.info('[Analyzer] Found parent template: $parentPath');
-          final parentSource = root!.resolve(parentPath);
-          final parentNodes = parseInput(parentSource.content);
 
-          // Process parent structure completely before continuing
-          var lastParentStructure = parentStructure;
-          for (final structure in _analyzeStructure(
-            parentPath,
-            parentNodes,
-            analysis,
-          )) {
-            lastParentStructure = structure;
-            if (lastParentStructure != null) {
-              analysis.structures[parentPath] = lastParentStructure;
+          // Check cache first for parent structure
+          if (_structureCache.containsKey(parentPath)) {
+            parentStructure = _structureCache[parentPath];
+            analysis.structures[parentPath] = parentStructure!;
+            logger.info(
+              '[Analyzer] Using cached parent structure: $parentPath',
+            );
+          } else {
+            // Parse parent (with caching)
+            List<ASTNode> parentNodes;
+            if (_parseCache.containsKey(parentPath)) {
+              parentNodes = _parseCache[parentPath]!;
+            } else {
+              final parentSource = root!.resolve(parentPath);
+              parentNodes = parseInput(parentSource.content);
+              _parseCache[parentPath] = parentNodes;
             }
+
+            // Process parent structure completely before continuing
+            var lastParentStructure = parentStructure;
+            for (final structure in _analyzeStructure(
+              parentPath,
+              parentNodes,
+              analysis,
+            )) {
+              lastParentStructure = structure;
+              if (lastParentStructure != null) {
+                analysis.structures[parentPath] = lastParentStructure;
+                _structureCache[parentPath] = lastParentStructure;
+              }
+            }
+            parentStructure = lastParentStructure;
           }
-          parentStructure = lastParentStructure;
 
           // Ensure parent blocks are fully processed
           if (parentStructure != null) {

--- a/pkgs/liquify/lib/src/analyzer/template_analyzer.dart
+++ b/pkgs/liquify/lib/src/analyzer/template_analyzer.dart
@@ -272,11 +272,9 @@ class TemplateAnalyzer {
               name: finalName,
               source: templatePath,
               content: node.body,
-              isOverride:
-                  isOverride ||
-                  hasOverriddenSubBlocks ||
-                  parentBlock != null ||
-                  parentStructure != null,
+              // A block is an override only if it actually exists in the parent chain
+              // Not just because there IS a parent template
+              isOverride: isOverride || hasOverriddenSubBlocks,
               parent: inheritedParent ?? parentBlock,
               nestedBlocks: {},
               hasSuperCall: foundSuper,

--- a/pkgs/liquify/lib/src/analyzer/template_structure.dart
+++ b/pkgs/liquify/lib/src/analyzer/template_structure.dart
@@ -334,6 +334,8 @@ class TemplateStructure {
   /// This method searches for a block through the entire template
   /// inheritance chain, including nested blocks.
   ///
+  /// Uses the cached [allBlockNames] set for O(1) lookup.
+  ///
   /// Parameters:
   /// * [blockName] - The name of the block to find
   ///
@@ -345,18 +347,5 @@ class TemplateStructure {
   ///   print('Navigation block exists in template hierarchy');
   /// }
   /// ```
-  bool hasBlockInChain(String blockName) {
-    // Check if this template has the block
-    if (blocks.containsKey(blockName)) {
-      return true;
-    }
-    // Check if any block in this template has the given block as a nested block
-    for (final block in blocks.values) {
-      if (block.nestedBlocks.containsKey(blockName)) {
-        return true;
-      }
-    }
-    // Check parent templates
-    return parent?.hasBlockInChain(blockName) ?? false;
-  }
+  bool hasBlockInChain(String blockName) => allBlockNames.contains(blockName);
 }

--- a/pkgs/liquify/lib/src/config.dart
+++ b/pkgs/liquify/lib/src/config.dart
@@ -1,0 +1,196 @@
+/// Configuration for Liquid template parsing.
+///
+/// This class holds delimiter configuration and other parser options.
+/// Create instances to customize how templates are parsed.
+///
+/// ## Basic Usage
+///
+/// ```dart
+/// // Custom delimiters
+/// final config = LiquidConfig(
+///   tagStart: '[%',
+///   tagEnd: '%]',
+///   varStart: '[[',
+///   varEnd: ']]',
+/// );
+///
+/// final liquid = Liquid(config: config);
+/// final template = liquid.parse('[% if user %]Hello [[name]]![% endif %]');
+/// print(template.render({'user': true, 'name': 'Alice'})); // Hello Alice!
+/// ```
+///
+/// ## Presets
+///
+/// Two presets are available for common use cases:
+///
+/// ```dart
+/// // Standard Liquid delimiters (default)
+/// final standard = LiquidConfig.standard;
+/// // Uses: {% %} for tags, {{ }} for variables
+///
+/// // ERB-style delimiters
+/// final erb = LiquidConfig.erb;
+/// // Uses: <% %> for tags, <%= %> for variables
+/// ```
+///
+/// ## Whitespace Control
+///
+/// The [stripMarker] (default: `-`) enables whitespace stripping when placed
+/// inside delimiters:
+///
+/// ```dart
+/// final liquid = Liquid();
+/// final template = liquid.parse('''
+///   {%- if true -%}
+///     Hello
+///   {%- endif -%}
+/// ''');
+/// print(template.render()); // 'Hello' (whitespace stripped)
+/// ```
+///
+/// ## Building Custom Tags
+///
+/// When building custom tags, use the factory functions with your config:
+///
+/// ```dart
+/// final config = LiquidConfig(tagStart: '[%', tagEnd: '%]');
+///
+/// // Create a custom tag parser
+/// Parser myTagParser() {
+///   return someTag('mytag', config: config);
+/// }
+/// ```
+///
+/// See also:
+/// - [Liquid] for parsing templates with custom delimiters
+/// - [LiquidTemplate] for rendering parsed templates
+/// - [createTagStart], [createTagEnd], [createVarStart], [createVarEnd] for
+///   building custom parsers
+class LiquidConfig {
+  /// The opening delimiter for tags. Default: `{%`
+  final String tagStart;
+
+  /// The closing delimiter for tags. Default: `%}`
+  final String tagEnd;
+
+  /// The opening delimiter for variable output. Default: `{{`
+  final String varStart;
+
+  /// The closing delimiter for variable output. Default: `}}`
+  final String varEnd;
+
+  /// The marker used for whitespace stripping. Default: `-`
+  ///
+  /// When placed inside a delimiter (e.g., `{{-` or `-%}`), it strips
+  /// whitespace from the adjacent text.
+  final String stripMarker;
+
+  /// Creates a new [LiquidConfig] with the specified delimiters.
+  ///
+  /// All parameters are optional and default to standard Liquid delimiters.
+  const LiquidConfig({
+    this.tagStart = '{%',
+    this.tagEnd = '%}',
+    this.varStart = '{{',
+    this.varEnd = '}}',
+    this.stripMarker = '-',
+  });
+
+  /// Standard Liquid delimiters (default).
+  ///
+  /// Uses `{% %}` for tags and `{{ }}` for variable output.
+  ///
+  /// ```dart
+  /// final liquid = Liquid(config: LiquidConfig.standard);
+  /// // Equivalent to: final liquid = Liquid();
+  /// ```
+  static const standard = LiquidConfig();
+
+  /// ERB-style delimiters.
+  ///
+  /// Uses `<% %>` for tags and `<%= %>` for variable output, similar to
+  /// Ruby's ERB templating system.
+  ///
+  /// ```dart
+  /// final liquid = Liquid(config: LiquidConfig.erb);
+  /// final template = liquid.parse('<% if user %>Hello <%= name %>!<% endif %>');
+  /// print(template.render({'user': true, 'name': 'World'})); // Hello World!
+  /// ```
+  static const erb = LiquidConfig(
+    tagStart: '<%',
+    tagEnd: '%>',
+    varStart: '<%=',
+    varEnd: '%>',
+  );
+
+  // Computed whitespace-stripping delimiter variants
+
+  /// Tag start with whitespace stripping (e.g., `{%-`)
+  String get tagStartStrip => '$tagStart$stripMarker';
+
+  /// Tag end with whitespace stripping (e.g., `-%}`)
+  String get tagEndStrip => '$stripMarker$tagEnd';
+
+  /// Variable start with whitespace stripping (e.g., `{{-`)
+  String get varStartStrip => '$varStart$stripMarker';
+
+  /// Variable end with whitespace stripping (e.g., `-}}`)
+  String get varEndStrip => '$stripMarker$varEnd';
+
+  /// Returns the first character(s) that could start a delimiter.
+  ///
+  /// Used by the text parser to know when to stop consuming text.
+  String get delimiterStartChars {
+    final chars = <String>{};
+    if (tagStart.isNotEmpty) chars.add(tagStart[0]);
+    if (varStart.isNotEmpty) chars.add(varStart[0]);
+    return chars.join();
+  }
+
+  /// Creates a copy of this config with the specified fields replaced.
+  ///
+  /// ```dart
+  /// final custom = LiquidConfig.standard.copyWith(
+  ///   tagStart: '<%',
+  ///   tagEnd: '%>',
+  /// );
+  /// // custom uses <% %> for tags but {{ }} for variables
+  /// ```
+  LiquidConfig copyWith({
+    String? tagStart,
+    String? tagEnd,
+    String? varStart,
+    String? varEnd,
+    String? stripMarker,
+  }) {
+    return LiquidConfig(
+      tagStart: tagStart ?? this.tagStart,
+      tagEnd: tagEnd ?? this.tagEnd,
+      varStart: varStart ?? this.varStart,
+      varEnd: varEnd ?? this.varEnd,
+      stripMarker: stripMarker ?? this.stripMarker,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is LiquidConfig &&
+        other.tagStart == tagStart &&
+        other.tagEnd == tagEnd &&
+        other.varStart == varStart &&
+        other.varEnd == varEnd &&
+        other.stripMarker == stripMarker;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(tagStart, tagEnd, varStart, varEnd, stripMarker);
+  }
+
+  @override
+  String toString() {
+    return 'LiquidConfig(tagStart: $tagStart, tagEnd: $tagEnd, '
+        'varStart: $varStart, varEnd: $varEnd, stripMarker: $stripMarker)';
+  }
+}

--- a/pkgs/liquify/lib/src/grammar/grammar.dart
+++ b/pkgs/liquify/lib/src/grammar/grammar.dart
@@ -1,6 +1,414 @@
 import 'package:liquify/src/grammar/shared.dart';
+import 'package:liquify/src/mixins/parser.dart';
+import 'package:liquify/src/tag_registry.dart';
 
+/// The main Liquid grammar that supports optional custom delimiters.
+///
+/// This grammar can be instantiated with a [LiquidConfig] to use custom
+/// delimiters instead of the standard `{% %}` and `{{ }}`.
+///
+/// ## Standard Usage
+///
+/// ```dart
+/// final grammar = LiquidGrammar();
+/// final parser = grammar.build();
+/// final result = parser.parse('Hello {{ name }}!');
+/// ```
+///
+/// ## Custom Delimiters
+///
+/// ```dart
+/// final config = LiquidConfig(
+///   tagStart: '[%', tagEnd: '%]',
+///   varStart: '[[', varEnd: ']]',
+/// );
+/// final grammar = LiquidGrammar(config);
+/// final parser = grammar.build();
+/// final result = parser.parse('Hello [[ name ]]!');
+/// ```
 class LiquidGrammar extends GrammarDefinition {
+  /// The delimiter configuration for this grammar.
+  ///
+  /// If null, uses standard Liquid delimiters (`{% %}` and `{{ }}`).
+  final LiquidConfig? config;
+
+  /// Creates a new Liquid grammar with optional custom delimiters.
+  ///
+  /// If [config] is null, uses standard Liquid delimiters.
+  LiquidGrammar([this.config]);
+
   @override
   Parser start() => ref0(document).end();
+
+  // ---------------------------------------------------------------------------
+  // Delimiter parsers - use config if provided
+  // ---------------------------------------------------------------------------
+
+  Parser configTagStart() => createTagStart(config);
+  Parser configTagEnd() => createTagEnd(config);
+  Parser configVarStart() => createVarStart(config);
+  Parser configVarEnd() => createVarEnd(config);
+
+  // ---------------------------------------------------------------------------
+  // Core document structure
+  // ---------------------------------------------------------------------------
+
+  Parser document() => ref0(element)
+      .plus()
+      .map((elements) {
+        var collapsedElements = collapseTextNodes(elements.cast<ASTNode>());
+        return Document(collapsedElements);
+      })
+      .labeled('document');
+
+  Parser element() {
+    final cfg = config ?? LiquidConfig.standard;
+
+    // Separate custom parsers by their delimiter type.
+    final varCustomParsers = <Parser>[];
+    final tagCustomParsers = <Parser>[];
+
+    for (final customParser in TagRegistry.customParsers) {
+      if (customParser.delimiterType == TagDelimiterType.variable) {
+        varCustomParsers.add(customParser.parser(config));
+      } else {
+        tagCustomParsers.add(customParser.parser(config));
+      }
+    }
+
+    // Variable-like elements (start with varStart or varStartStrip)
+    final variableElements = [
+      ...varCustomParsers,
+      ref0(variable),
+    ].toChoiceParser();
+
+    // Tag/block parsers (start with tagStart or tagStartStrip)
+    final tagElements = [
+      ref0(ifBlock),
+      ref0(forBlock),
+      ref0(caseBlock),
+      ref0(whenBlock),
+      ref0(elseBlockForCase),
+      ref0(elseBlockForFor),
+      ref0(hashBlockComment),
+      ...tagCustomParsers,
+      ref0(tag),
+    ].toChoiceParser();
+
+    // Text parser
+    final textElement = ref0(text);
+
+    // Lookahead parsers for delimiters
+    final tagLookahead =
+        (string(cfg.tagStartStrip).trim() | string(cfg.tagStart)).and();
+    final varLookahead =
+        (string(cfg.varStartStrip).trim() | string(cfg.varStart)).and();
+
+    return ((varLookahead & variableElements).pick(1) |
+            (tagLookahead & tagElements).pick(1) |
+            textElement)
+        .labeled('element');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Variable parser
+  // ---------------------------------------------------------------------------
+
+  Parser variable() =>
+      (ref0(configVarStart) &
+              ref0(expression).trim() &
+              filter().star().trim() &
+              ref0(configVarEnd))
+          .map((values) {
+            ASTNode expr = values[1];
+            var filters = values[2] as List;
+
+            String name = '';
+            if (expr is Identifier) {
+              name = expr.name;
+            } else if (expr is MemberAccess) {
+              name = (expr.object as Identifier).name;
+            }
+
+            if (filters.isNotEmpty) {
+              return FilteredExpression(
+                Variable(name, expr),
+                filters.cast<Filter>(),
+              );
+            }
+
+            return Variable(name, expr);
+          })
+          .labeled('variable');
+
+  // ---------------------------------------------------------------------------
+  // Text parser - config-aware for custom delimiters
+  // ---------------------------------------------------------------------------
+
+  Parser text() {
+    final cfg = config ?? LiquidConfig.standard;
+
+    // Build character class for delimiter start characters
+    final delimiterChars = cfg.delimiterStartChars;
+
+    // Any character except delimiter start chars and whitespace is definitely safe
+    final safeCharPattern = '^$delimiterChars \t\r\n';
+    final safeChar = pattern(safeCharPattern);
+
+    // A delimiter start char is safe if not followed by the rest of the delimiter
+    final safeBrace = _safeDelimiterChar(cfg);
+
+    // Whitespace is safe if not followed by strip delimiters
+    final safeWhitespace =
+        pattern(' \t\r\n') &
+        (string(cfg.varStartStrip) | string(cfg.tagStartStrip)).not();
+
+    final textChar =
+        safeChar | safeBrace | safeWhitespace.map((values) => values[0]);
+
+    return textChar
+        .plus()
+        .flatten()
+        .map((text) => TextNode(text))
+        .labeled('text block');
+  }
+
+  /// Creates a parser for delimiter start characters that are safe (not starting a real delimiter).
+  Parser _safeDelimiterChar(LiquidConfig cfg) {
+    final firstChars = <String>{};
+    if (cfg.tagStart.isNotEmpty) firstChars.add(cfg.tagStart[0]);
+    if (cfg.varStart.isNotEmpty) firstChars.add(cfg.varStart[0]);
+
+    if (firstChars.isEmpty) {
+      return any();
+    }
+
+    final parsers = <Parser>[];
+    for (final ch in firstChars) {
+      final followups = <String>[];
+      if (cfg.tagStart.isNotEmpty && cfg.tagStart[0] == ch) {
+        followups.add(cfg.tagStart.substring(1));
+      }
+      if (cfg.varStart.isNotEmpty && cfg.varStart[0] == ch) {
+        followups.add(cfg.varStart.substring(1));
+      }
+
+      if (followups.isEmpty) {
+        parsers.add(char(ch));
+      } else {
+        final followupParser = followups
+            .map((f) => string(f))
+            .toList()
+            .toChoiceParser();
+        parsers.add(
+          (char(ch) & followupParser.not()).map((values) => values[0]),
+        );
+      }
+    }
+
+    return parsers.toChoiceParser();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tag parser
+  // ---------------------------------------------------------------------------
+
+  Parser tag() {
+    return (ref0(configTagStart) &
+            ref0(identifier).trim() &
+            ref0(configTagContent).optional().trim() &
+            ref0(filter).star().trim() &
+            ref0(configTagEnd))
+        .map((values) {
+          final name = (values[1] as Identifier).name;
+          final content = collapseTextNodes(values[2] as List<ASTNode>? ?? []);
+          final filters = (values[3] as List).cast<Filter>();
+          final nonFilterContent = content
+              .where((node) => node is! Filter)
+              .toList();
+          return Tag(name, nonFilterContent, filters: filters);
+        })
+        .labeled('tag');
+  }
+
+  Parser configTagContent() {
+    return (ref0(argument) | ref0(expression))
+        .star()
+        .map((values) {
+          var res = [];
+          for (final entry in values) {
+            if (entry is List) {
+              res.addAll(entry);
+            } else {
+              res.add(entry);
+            }
+          }
+          return res.cast<ASTNode>();
+        })
+        .labeled('tagContent');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hash block comment
+  // ---------------------------------------------------------------------------
+
+  Parser hashBlockComment() =>
+      (ref0(configTagStart) &
+              pattern(' \t\n\r').star() &
+              char('#') &
+              any().starLazy(ref0(configTagEnd)).flatten() &
+              ref0(configTagEnd))
+          .map((values) => TextNode(''))
+          .labeled('hashBlockComment');
+
+  // ---------------------------------------------------------------------------
+  // If block
+  // ---------------------------------------------------------------------------
+
+  Parser<Tag> ifTag() => someTag("if", config: config).labeled('ifTag');
+  Parser<Tag> elsifTag() =>
+      someTag("elsif", config: config).labeled('elsifTag');
+  Parser<Tag> elseTag() =>
+      someTag('else', config: config, hasContent: false).labeled('elseTag');
+
+  Parser endIfTag() =>
+      (ref0(configTagStart) & string('endif').trim() & ref0(configTagEnd))
+          .map((values) => Tag('endif', []))
+          .labeled('endIfTag');
+
+  Parser ifBranchContent() => ref0(element)
+      .starLazy(ref0(elsifTag).or(ref0(elseTag)).or(ref0(endIfTag)))
+      .labeled('ifBranchContent');
+
+  Parser elsifBranchContent() => ref0(element)
+      .starLazy(ref0(elsifTag).or(ref0(elseTag)).or(ref0(endIfTag)))
+      .labeled('elsifBranchContent');
+
+  Parser elseBranchContent() =>
+      ref0(element).starLazy(ref0(endIfTag)).labeled('elseBranchContent');
+
+  Parser elseIfBlock() => seq2(ref0(elsifTag), ref0(elsifBranchContent))
+      .map((values) {
+        final elsifTag = values.$1;
+        final elsifBody = (values.$2 as List).cast<ASTNode>();
+        return elsifTag.copyWith(body: elsifBody);
+      })
+      .labeled('elseIfBlock');
+
+  Parser elseBlock() => seq2(ref0(elseTag), ref0(elseBranchContent))
+      .map((values) {
+        final elseTag = values.$1;
+        final elseBody = (values.$2 as List).cast<ASTNode>();
+        return elseTag.copyWith(body: elseBody);
+      })
+      .labeled('elseBlock');
+
+  Parser ifBlock() =>
+      seq5(
+            ref0(ifTag),
+            ref0(ifBranchContent),
+            ref0(elseIfBlock).star(),
+            ref0(elseBlock).optional(),
+            ref0(endIfTag),
+          )
+          .map((values) {
+            final ifTag = values.$1;
+            final ifBody = (values.$2 as List).cast<ASTNode>();
+            final elsifBlocks = (values.$3).cast<Tag>();
+            final elseBlock = values.$4 as Tag?;
+
+            final List<ASTNode> allBodyNodes = [...ifBody];
+            for (var block in elsifBlocks) {
+              allBodyNodes.add(block);
+            }
+            if (elseBlock != null) {
+              allBodyNodes.add(elseBlock);
+            }
+
+            return ifTag.copyWith(body: allBodyNodes);
+          })
+          .labeled('ifBlock');
+
+  // ---------------------------------------------------------------------------
+  // For block
+  // ---------------------------------------------------------------------------
+
+  Parser<Tag> forTag() => someTag('for', config: config).labeled('forTag');
+
+  Parser endForTag() =>
+      (ref0(configTagStart) & string('endfor').trim() & ref0(configTagEnd))
+          .map((values) => Tag('endfor', []))
+          .labeled('endForTag');
+
+  Parser forElseBranchContent() =>
+      ref0(element).starLazy(ref0(endForTag)).labeled('forElseBranchContent');
+
+  Parser elseBlockForFor() => seq2(ref0(elseTag), ref0(forElseBranchContent))
+      .map((values) {
+        return (values.$1).copyWith(body: (values.$2 as List).cast<ASTNode>());
+      })
+      .labeled('elseBlockForFor');
+
+  Parser forBlock() =>
+      seq4(
+            ref0(forTag),
+            ref0(element).starLazy(ref0(elseTag).or(ref0(endForTag))),
+            ref0(elseBlockForFor).optional(),
+            ref0(endForTag),
+          )
+          .map((values) {
+            final forTag = values.$1;
+            final forBody = (values.$2).cast<ASTNode>();
+            final elseBlockForFor = values.$3 as Tag?;
+
+            final List<ASTNode> allBodyNodes = [...forBody];
+            if (elseBlockForFor != null) {
+              allBodyNodes.add(elseBlockForFor);
+            }
+
+            return forTag.copyWith(body: allBodyNodes);
+          })
+          .labeled('forBlock');
+
+  // ---------------------------------------------------------------------------
+  // Case block
+  // ---------------------------------------------------------------------------
+
+  Parser<Tag> whenTag() => someTag('when', config: config).labeled('whenTag');
+  Parser<Tag> caseTag() => someTag('case', config: config).labeled('caseTag');
+
+  Parser endCaseTag() =>
+      (ref0(configTagStart) & string('endcase').trim() & ref0(configTagEnd))
+          .map((values) => Tag('endcase', []))
+          .labeled('endCaseTag');
+
+  Parser whenBlock() =>
+      seq2(
+            ref0(whenTag),
+            ref0(
+              element,
+            ).starLazy(ref0(whenTag).or(ref0(elseTag)).or(ref0(endCaseTag))),
+          )
+          .map((values) {
+            return (values.$1).copyWith(body: (values.$2).cast<ASTNode>());
+          })
+          .labeled('whenBlock');
+
+  Parser elseBlockForCase() =>
+      seq2(ref0(elseTag), ref0(element).starLazy(ref0(endCaseTag)))
+          .map((values) {
+            return (values.$1).copyWith(body: (values.$2).cast<ASTNode>());
+          })
+          .labeled('elseBlockForCase');
+
+  Parser caseBlock() =>
+      seq3(
+            ref0(caseTag),
+            ref0(element).starLazy(ref0(endCaseTag)),
+            ref0(endCaseTag),
+          )
+          .map((values) {
+            return (values.$1).copyWith(body: (values.$2).cast<ASTNode>());
+          })
+          .labeled('caseBlock');
 }

--- a/pkgs/liquify/lib/src/grammar/shared.dart
+++ b/pkgs/liquify/lib/src/grammar/shared.dart
@@ -901,8 +901,8 @@ Parser elseBlock() => seq2(ref0(elseTag), ref0(elseBranchContent))
 /// to properly handle Liquid's whitespace control syntax.
 Parser element() {
   // Separate custom parsers by their delimiter type.
-  // Custom parsers that use {{ }} syntax (like SuperTag) need to be in the
-  // variable branch, while those using {% %} syntax go in the tag branch.
+  // Custom parsers that use {{ }} syntax (like SuperTag) go in variable branch,
+  // those using {% %} syntax (default) go in tag branch.
   final varCustomParsers = <Parser>[];
   final tagCustomParsers = <Parser>[];
 

--- a/pkgs/liquify/lib/src/grammar/shared.dart
+++ b/pkgs/liquify/lib/src/grammar/shared.dart
@@ -138,8 +138,18 @@ Parser namedArgument() {
 /// _comparisonExpr, _arithmeticExpr, and primaryTerm.
 /// Kept for backwards compatibility and testing.
 
+/// Identifier parser - matches variable names, function names, etc.
+///
+/// Identifiers must start with a letter and can contain letters, digits,
+/// underscores, and hyphens. Reserved words (and, or, not, contains) are excluded.
+///
+/// Optimized to use pattern() instead of word() | char('-') for better performance.
+/// Pattern matching is more efficient than choice parsers for character classes.
 Parser identifier() {
-  return (letter() & (word() | char('-')).star())
+  // Use pattern for efficient character class matching
+  // First char: letter only
+  // Rest: letters, digits, underscore, or hyphen
+  return (pattern('a-zA-Z') & pattern('a-zA-Z0-9_-').star())
       .flatten()
       .where((name) => !['and', 'or', 'not', 'contains'].contains(name))
       .map((name) => Identifier(name))

--- a/pkgs/liquify/lib/src/liquid.dart
+++ b/pkgs/liquify/lib/src/liquid.dart
@@ -1,0 +1,374 @@
+import 'package:liquify/src/ast.dart';
+import 'package:liquify/src/config.dart';
+import 'package:liquify/src/context.dart';
+import 'package:liquify/src/evaluator.dart';
+import 'package:liquify/src/fs.dart';
+import 'package:liquify/src/grammar/grammar.dart';
+import 'package:liquify/src/registry.dart';
+import 'package:liquify/src/buffer.dart';
+import 'package:liquify/src/render_target.dart';
+import 'package:liquify/src/tag_registry.dart';
+import 'package:petitparser/petitparser.dart';
+
+/// The main entry point for Liquid template parsing and rendering.
+///
+/// A [Liquid] instance holds configuration (including custom delimiters)
+/// and provides methods to parse and render templates.
+///
+/// ## Basic Usage
+///
+/// ```dart
+/// final liquid = Liquid();
+/// final template = liquid.parse('Hello {{ name }}!');
+/// final result = template.render({'name': 'World'});
+/// print(result); // Hello World!
+/// ```
+///
+/// ## Custom Delimiters
+///
+/// ```dart
+/// final liquid = Liquid(
+///   config: LiquidConfig(
+///     tagStart: '[%',
+///     tagEnd: '%]',
+///     varStart: '[[',
+///     varEnd: ']]',
+///   ),
+/// );
+/// final template = liquid.parse('[% if user %]Hello [[name]]![% endif %]');
+/// final result = template.render({'user': true, 'name': 'Alice'});
+/// print(result); // Hello Alice!
+/// ```
+///
+/// ## Convenience Constructor
+///
+/// ```dart
+/// final liquid = Liquid.withDelimiters(
+///   tagStart: '<%',
+///   tagEnd: '%>',
+///   varStart: '<%=',
+///   varEnd: '%>',
+/// );
+/// ```
+///
+/// ## One-Shot Rendering
+///
+/// For templates rendered only once, use [renderString]:
+///
+/// ```dart
+/// final liquid = Liquid();
+/// final result = liquid.renderString('Hello {{ name }}!', {'name': 'World'});
+/// ```
+///
+/// ## File-Based Templates
+///
+/// ```dart
+/// final liquid = Liquid(root: Root.fs('/templates'));
+/// final template = liquid.parseFile('greeting.liquid');
+/// final result = template.render({'name': 'World'});
+/// ```
+///
+/// ## Multiple Instances
+///
+/// You can create multiple [Liquid] instances with different configurations:
+///
+/// ```dart
+/// final standard = Liquid(); // Default delimiters
+/// final erb = Liquid(config: LiquidConfig.erb); // ERB-style
+/// final custom = Liquid.withDelimiters(tagStart: '<<', tagEnd: '>>');
+/// ```
+///
+/// See also:
+/// - [LiquidConfig] for delimiter configuration options
+/// - [LiquidTemplate] for template rendering methods
+/// - [Template] for the legacy API (uses default delimiters only)
+class Liquid {
+  /// The configuration for this Liquid instance.
+  final LiquidConfig config;
+
+  /// Optional file system root for resolving templates.
+  final Root? root;
+
+  // Cached parser for this configuration
+  Parser? _cachedParser;
+  int? _cachedSignature;
+
+  /// Creates a new [Liquid] instance with the given configuration.
+  ///
+  /// If [config] is not provided, standard Liquid delimiters are used.
+  /// If [root] is provided, it will be used to resolve file-based templates.
+  Liquid({this.config = const LiquidConfig(), this.root});
+
+  /// Creates a [Liquid] instance with custom delimiters.
+  ///
+  /// This is a convenience constructor for common use cases.
+  ///
+  /// Example:
+  /// ```dart
+  /// final liquid = Liquid.withDelimiters(
+  ///   tagStart: '[%',
+  ///   tagEnd: '%]',
+  ///   varStart: '[[',
+  ///   varEnd: ']]',
+  /// );
+  /// ```
+  factory Liquid.withDelimiters({
+    String tagStart = '{%',
+    String tagEnd = '%}',
+    String varStart = '{{',
+    String varEnd = '}}',
+    String stripMarker = '-',
+    Root? root,
+  }) {
+    return Liquid(
+      config: LiquidConfig(
+        tagStart: tagStart,
+        tagEnd: tagEnd,
+        varStart: varStart,
+        varEnd: varEnd,
+        stripMarker: stripMarker,
+      ),
+      root: root,
+    );
+  }
+
+  /// Parses a template string and returns a [LiquidTemplate].
+  ///
+  /// The returned template can be rendered multiple times with different data.
+  ///
+  /// Throws [ParsingException] if the template contains syntax errors.
+  LiquidTemplate parse(String source) {
+    if (source.isEmpty) {
+      return LiquidTemplate._([], this);
+    }
+
+    final parser = _getParser();
+    final result = parser.parse(source);
+
+    if (result is Success) {
+      return LiquidTemplate._((result.value as Document).children, this);
+    }
+
+    final lineCol = Token.lineAndColumnOf(source, result.position);
+    throw ParsingException(
+      result.message,
+      source,
+      lineCol[0],
+      lineCol[1],
+      result.position,
+    );
+  }
+
+  /// Parses a template from a file.
+  ///
+  /// Requires a [Root] to be configured either in the constructor or passed
+  /// as a parameter.
+  ///
+  /// Throws [StateError] if no root is configured.
+  /// Throws [TemplateNotFoundException] if the file cannot be found.
+  LiquidTemplate parseFile(String filename, [Root? fileRoot]) {
+    final resolvedRoot = fileRoot ?? root;
+    if (resolvedRoot == null) {
+      throw StateError(
+        'No Root configured. Pass a Root to parseFile() or configure one in the Liquid constructor.',
+      );
+    }
+
+    final source = resolvedRoot.resolve(filename);
+    final template = parse(source.content);
+    template._root = resolvedRoot;
+    return template;
+  }
+
+  /// Convenience method to parse and render a template in one step.
+  ///
+  /// For templates that will be rendered multiple times, use [parse] instead
+  /// to avoid re-parsing.
+  String renderString(String source, [Map<String, dynamic> data = const {}]) {
+    return parse(source).render(data);
+  }
+
+  /// Convenience method to parse and render a template asynchronously.
+  Future<String> renderStringAsync(
+    String source, [
+    Map<String, dynamic> data = const {},
+  ]) {
+    return parse(source).renderAsync(data);
+  }
+
+  Parser _getParser() {
+    registerBuiltIns();
+    final signature = _parserSignature();
+    if (_cachedParser == null || _cachedSignature != signature) {
+      _cachedParser = LiquidGrammar(config).build();
+      _cachedSignature = signature;
+    }
+    return _cachedParser!;
+  }
+
+  int _parserSignature() {
+    // Include config in signature so parser is rebuilt if config changes
+    final customParsers = TagRegistry.customParsers;
+    return Object.hash(
+      config,
+      Object.hashAll(customParsers.map((p) => p.runtimeType)),
+    );
+  }
+}
+
+/// A parsed Liquid template that can be rendered with different data.
+///
+/// Create instances using [Liquid.parse] or [Liquid.parseFile].
+///
+/// ## Basic Rendering
+///
+/// ```dart
+/// final liquid = Liquid();
+/// final template = liquid.parse('Hello {{ name }}!');
+///
+/// // Render with data
+/// print(template.render({'name': 'World'})); // Hello World!
+///
+/// // Render multiple times with different data
+/// print(template.render({'name': 'Alice'})); // Hello Alice!
+/// print(template.render({'name': 'Bob'}));   // Hello Bob!
+/// ```
+///
+/// ## Async Rendering
+///
+/// Use [renderAsync] when the template may contain async operations:
+///
+/// ```dart
+/// final result = await template.renderAsync({'name': 'World'});
+/// ```
+///
+/// ## Custom Environment
+///
+/// ```dart
+/// final result = template.render(
+///   {'name': 'World'},
+///   null,
+///   (env) {
+///     env.registerLocalFilter('shout', (value, args, namedArgs) =>
+///       value.toString().toUpperCase());
+///   },
+/// );
+/// ```
+///
+/// ## Render to Custom Target
+///
+/// ```dart
+/// final result = template.renderTo(
+///   MyRenderTarget(),
+///   {'name': 'World'},
+/// );
+/// ```
+class LiquidTemplate {
+  final List<ASTNode> _nodes;
+  final Liquid _liquid;
+  Root? _root;
+
+  LiquidTemplate._(this._nodes, this._liquid);
+
+  /// The configuration used to parse this template.
+  LiquidConfig get config => _liquid.config;
+
+  /// Renders the template with the given data.
+  ///
+  /// [data] is a map of variables available in the template.
+  /// [environment] optionally provides a custom environment with filters/tags.
+  /// [environmentSetup] optionally configures the environment before rendering.
+  String render([
+    Map<String, dynamic> data = const {},
+    Environment? environment,
+    void Function(Environment)? environmentSetup,
+  ]) {
+    final env = _createEnvironment(data, environment, environmentSetup);
+    final evaluator = Evaluator(env);
+    evaluator.evaluateNodes(_nodes);
+    return evaluator.buffer.toString();
+  }
+
+  /// Renders the template asynchronously.
+  ///
+  /// Use this when the template contains async operations like file includes.
+  Future<String> renderAsync([
+    Map<String, dynamic> data = const {},
+    Environment? environment,
+    void Function(Environment)? environmentSetup,
+  ]) async {
+    final env = _createEnvironment(data, environment, environmentSetup);
+    final evaluator = Evaluator(env);
+    await evaluator.evaluateNodesAsync(_nodes);
+    return evaluator.buffer.toString();
+  }
+
+  /// Renders the template to a custom target.
+  R renderTo<R>(
+    RenderTarget<R> target, [
+    Map<String, dynamic> data = const {},
+    Environment? environment,
+    void Function(Environment)? environmentSetup,
+  ]) {
+    final env = _createEnvironment(data, environment, environmentSetup);
+    final evaluator = Evaluator(env);
+    final sink = target.createSink();
+    final buffer = Buffer(sink: sink);
+    return evaluator.withBuffer(buffer, () {
+      evaluator.evaluateNodes(_nodes);
+      return target.finalize(sink);
+    });
+  }
+
+  Environment _createEnvironment(
+    Map<String, dynamic> data,
+    Environment? environment,
+    void Function(Environment)? environmentSetup,
+  ) {
+    Environment env;
+    if (environment != null) {
+      env = environment.clone();
+      env.merge(data);
+    } else {
+      env = Environment(data);
+    }
+
+    // Set the config so tags can use it for re-parsing
+    env.setConfig(_liquid.config);
+
+    if (_root != null) {
+      env.setRoot(_root);
+    }
+
+    if (environmentSetup != null) {
+      environmentSetup(env);
+    }
+
+    return env;
+  }
+}
+
+/// Represents an exception that occurred during parsing.
+class ParsingException implements Exception {
+  final String message;
+  final String source;
+  final int line;
+  final int column;
+  final int offset;
+
+  ParsingException(
+    this.message,
+    this.source,
+    this.line,
+    this.column,
+    this.offset,
+  );
+
+  @override
+  String toString() {
+    final lines = source.split('\n');
+    final errorLine = line <= lines.length ? lines[line - 1] : '';
+    final pointer = '${' ' * (column - 1)}^';
+    return 'ParsingException: $message @ line $line:$column\nsource: \n$errorLine\n$pointer';
+  }
+}

--- a/pkgs/liquify/lib/src/mixins/parser.dart
+++ b/pkgs/liquify/lib/src/mixins/parser.dart
@@ -16,7 +16,11 @@ mixin CustomTagParser {
 
   /// The delimiter type this tag uses.
   ///
-  /// Override this to return [TagDelimiterType.variable] if your custom tag
-  /// uses {{ }} syntax instead of {% %}.
+  /// Defaults to [TagDelimiterType.tag] for standard {% %} syntax.
+  /// Override to [TagDelimiterType.variable] if your custom tag
+  /// uses {{ }} syntax instead (e.g., {{ super() }}).
+  ///
+  /// **Breaking change in 2.0.0:** Custom tags using {{ }} syntax must now
+  /// explicitly override this getter to return [TagDelimiterType.variable].
   TagDelimiterType get delimiterType => TagDelimiterType.tag;
 }

--- a/pkgs/liquify/lib/src/mixins/parser.dart
+++ b/pkgs/liquify/lib/src/mixins/parser.dart
@@ -1,3 +1,4 @@
+import 'package:liquify/src/config.dart';
 import 'package:petitparser/petitparser.dart';
 
 /// Indicates the delimiter type used by a custom tag parser.
@@ -9,8 +10,90 @@ enum TagDelimiterType {
   variable,
 }
 
+/// Mixin for custom tag parsers.
+///
+/// Implement this mixin to create custom tags with custom parsing logic.
+///
+/// ## Basic Usage
+///
+/// ```dart
+/// class MyTag extends AbstractTag with CustomTagParser {
+///   MyTag(super.content, super.filters);
+///
+///   @override
+///   Parser parser([LiquidConfig? config]) {
+///     return someTag('mytag', config: config);
+///   }
+/// }
+/// ```
+///
+/// ## Custom Delimiters
+///
+/// When [parser] is called with a [LiquidConfig], use the factory functions
+/// with that config to support custom delimiters:
+///
+/// ```dart
+/// @override
+/// Parser parser([LiquidConfig? config]) {
+///   return (createTagStart(config) &
+///           string('mytag').trim() &
+///           createTagEnd(config))
+///       .map((_) => Tag('mytag', []));
+/// }
+/// ```
+///
+/// ## Accessing Config During Evaluation
+///
+/// If your tag needs to re-parse content (e.g., a block tag with nested Liquid
+/// syntax), access the config from the evaluator's context:
+///
+/// ```dart
+/// @override
+/// dynamic evaluate(Evaluator evaluator, Buffer buffer) {
+///   final content = body[0].toString();
+///
+///   // Get the config to use the same delimiters as the parent template
+///   final config = evaluator.context.config;
+///   final liquid = Liquid(config: config ?? LiquidConfig.standard);
+///
+///   // Re-parse and render with the correct delimiters
+///   final result = liquid.renderString(content, evaluator.context.all());
+///   buffer.write(result);
+/// }
+/// ```
+///
+/// ## Variable-Style Tags
+///
+/// For tags that use `{{ }}` syntax (like `{{ super() }}`), override
+/// [delimiterType] to return [TagDelimiterType.variable]:
+///
+/// ```dart
+/// @override
+/// TagDelimiterType get delimiterType => TagDelimiterType.variable;
+///
+/// @override
+/// Parser parser([LiquidConfig? config]) {
+///   return (createVarStart(config) &
+///           string('super').trim() &
+///           char('(').trim() &
+///           char(')').trim() &
+///           createVarEnd(config))
+///       .map((_) => Tag('super', []));
+/// }
+/// ```
 mixin CustomTagParser {
-  Parser parser() {
+  /// Returns the parser for this custom tag.
+  ///
+  /// Override this method to define the parsing logic for your custom tag.
+  ///
+  /// The optional [config] parameter provides the delimiter configuration.
+  /// When building parsers, use the factory functions with this config:
+  /// - [createTagStart], [createTagEnd] for tag delimiters
+  /// - [createVarStart], [createVarEnd] for variable delimiters
+  /// - [someTag] for complete tag parsers
+  ///
+  /// If [config] is null, standard Liquid delimiters are used.
+  Parser parser([LiquidConfig? config]) {
     return epsilon();
   }
 
@@ -19,8 +102,5 @@ mixin CustomTagParser {
   /// Defaults to [TagDelimiterType.tag] for standard {% %} syntax.
   /// Override to [TagDelimiterType.variable] if your custom tag
   /// uses {{ }} syntax instead (e.g., {{ super() }}).
-  ///
-  /// **Breaking change in 2.0.0:** Custom tags using {{ }} syntax must now
-  /// explicitly override this getter to return [TagDelimiterType.variable].
   TagDelimiterType get delimiterType => TagDelimiterType.tag;
 }

--- a/pkgs/liquify/lib/src/mixins/parser.dart
+++ b/pkgs/liquify/lib/src/mixins/parser.dart
@@ -1,7 +1,22 @@
 import 'package:petitparser/petitparser.dart';
 
+/// Indicates the delimiter type used by a custom tag parser.
+enum TagDelimiterType {
+  /// Uses {% %} delimiters (standard tag syntax)
+  tag,
+
+  /// Uses {{ }} delimiters (variable-like syntax, e.g., {{ super() }})
+  variable,
+}
+
 mixin CustomTagParser {
   Parser parser() {
     return epsilon();
   }
+
+  /// The delimiter type this tag uses.
+  ///
+  /// Override this to return [TagDelimiterType.variable] if your custom tag
+  /// uses {{ }} syntax instead of {% %}.
+  TagDelimiterType get delimiterType => TagDelimiterType.tag;
 }

--- a/pkgs/liquify/lib/src/tags/block.dart
+++ b/pkgs/liquify/lib/src/tags/block.dart
@@ -23,15 +23,12 @@ class BlockTag extends AbstractTag with CustomTagParser {
   }
 
   @override
-  Parser parser() {
-    return ((tagStart() &
-                string('block').trim() &
-                ref0(identifier).trim() &
-                tagEnd()) &
-            ref0(
-              element,
-            ).starLazy(tagStart() & string('endblock').trim() & tagEnd()) &
-            (tagStart() & string('endblock').trim() & tagEnd()))
+  Parser parser([LiquidConfig? config]) {
+    final start = createTagStart(config);
+    final end = createTagEnd(config);
+    return ((start & string('block').trim() & ref0(identifier).trim() & end) &
+            ref0(element).starLazy(start & string('endblock').trim() & end) &
+            (start & string('endblock').trim() & end))
         .map((values) {
           final tag = Tag('block', [
             values[2] as ASTNode,

--- a/pkgs/liquify/lib/src/tags/capture.dart
+++ b/pkgs/liquify/lib/src/tags/capture.dart
@@ -48,11 +48,11 @@ class CaptureTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 
   @override
-  Parser parser() {
+  Parser parser([LiquidConfig? config]) {
     return seq3(
-      tagStart() & string('capture').trim(),
+      createTagStart(config) & string('capture').trim(),
       ref0(identifier).trim(),
-      tagEnd(),
+      createTagEnd(config),
     ).map((values) {
       return Tag('capture', [values.$2 as ASTNode]);
     });

--- a/pkgs/liquify/lib/src/tags/comment.dart
+++ b/pkgs/liquify/lib/src/tags/comment.dart
@@ -13,16 +13,18 @@ class CommentTag extends AbstractTag with CustomTagParser, AsyncTag {
   ) async {}
 
   @override
-  Parser parser() {
-    return (tagStart() &
+  Parser parser([LiquidConfig? config]) {
+    final start = createTagStart(config);
+    final end = createTagEnd(config);
+    return (start &
             string('comment').trim() &
-            tagEnd() &
+            end &
             any()
-                .starLazy((tagStart() & string('endcomment').trim() & tagEnd()))
+                .starLazy((start & string('endcomment').trim() & end))
                 .flatten() &
-            tagStart() &
+            start &
             string('endcomment').trim() &
-            tagEnd())
+            end)
         .map((values) {
           return Tag("comment", [TextNode(values[3])]);
         });

--- a/pkgs/liquify/lib/src/tags/cycle.dart
+++ b/pkgs/liquify/lib/src/tags/cycle.dart
@@ -80,11 +80,11 @@ class CycleTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 
   @override
-  Parser parser() {
+  Parser parser([LiquidConfig? config]) {
     return seq3(
-      tagStart() & string('cycle').trim(),
+      createTagStart(config) & string('cycle').trim(),
       ref0(cycleArguments).trim(),
-      tagEnd(),
+      createTagEnd(config),
     ).map((values) {
       return Tag(
         'cycle',

--- a/pkgs/liquify/lib/src/tags/doc_tag.dart
+++ b/pkgs/liquify/lib/src/tags/doc_tag.dart
@@ -13,16 +13,16 @@ class DocTag extends AbstractTag with CustomTagParser, AsyncTag {
   ) async {}
 
   @override
-  Parser parser() {
-    return (tagStart() &
+  Parser parser([LiquidConfig? config]) {
+    final start = createTagStart(config);
+    final end = createTagEnd(config);
+    return (start &
             string('doc').trim() &
-            tagEnd() &
-            any()
-                .starLazy((tagStart() & string('enddoc').trim() & tagEnd()))
-                .flatten() &
-            tagStart() &
+            end &
+            any().starLazy((start & string('enddoc').trim() & end)).flatten() &
+            start &
             string('enddoc').trim() &
-            tagEnd())
+            end)
         .map((values) {
           return Tag("doc", [TextNode(values[3])]);
         });

--- a/pkgs/liquify/lib/src/tags/layout.dart
+++ b/pkgs/liquify/lib/src/tags/layout.dart
@@ -49,14 +49,16 @@ class LayoutTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 
   @override
-  Parser parser() {
-    return ((tagStart() &
+  Parser parser([LiquidConfig? config]) {
+    final start = createTagStart(config);
+    final end = createTagEnd(config);
+    return ((start &
                 string('layout').trim() &
                 ref0(identifier).or(ref0(stringLiteral)).trim() &
                 ref0(
                   namedArgument,
                 ).star().starSeparated(char(',') | whitespace()).trim() &
-                tagEnd()) &
+                end) &
             ref0(element).star())
         .map((values) {
           final arguments = [values[2] as ASTNode];

--- a/pkgs/liquify/lib/src/tags/liquid.dart
+++ b/pkgs/liquify/lib/src/tags/liquid.dart
@@ -36,17 +36,17 @@ class LiquidTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 
   @override
-  Parser parser() =>
-      (tagStart() &
-              string('liquid').trim() &
-              any().starLazy(tagEnd()).flatten() &
-              tagEnd())
-          .map((values) {
-            return Tag(
-              "liquid",
-              liquidTagContents(values[2], TagRegistry.tags),
-            );
-          });
+  Parser parser([LiquidConfig? config]) {
+    final start = createTagStart(config);
+    final end = createTagEnd(config);
+    return (start &
+            string('liquid').trim() &
+            any().starLazy(end).flatten() &
+            end)
+        .map((values) {
+          return Tag("liquid", liquidTagContents(values[2], TagRegistry.tags));
+        });
+  }
 
   List<ASTNode> liquidTagContents(String content, List<String> tagRegistry) {
     if (content.contains('\r') && !content.contains('\n')) {

--- a/pkgs/liquify/lib/src/tags/raw.dart
+++ b/pkgs/liquify/lib/src/tags/raw.dart
@@ -32,16 +32,16 @@ class RawTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 
   @override
-  Parser parser() {
-    return (tagStart() &
+  Parser parser([LiquidConfig? config]) {
+    final start = createTagStart(config);
+    final end = createTagEnd(config);
+    return (start &
             string('raw').trim() &
-            tagEnd() &
-            any()
-                .starLazy((tagStart() & string('endraw').trim() & tagEnd()))
-                .flatten() &
-            tagStart() &
+            end &
+            any().starLazy((start & string('endraw').trim() & end)).flatten() &
+            start &
             string('endraw').trim() &
-            tagEnd())
+            end)
         .map((values) {
           return Tag("raw", [TextNode(values[3])]);
         });

--- a/pkgs/liquify/lib/src/tags/repeat.dart
+++ b/pkgs/liquify/lib/src/tags/repeat.dart
@@ -49,22 +49,25 @@ class RepeatTag extends AbstractTag with AsyncTag, CustomTagParser {
     buffer.write(filtered);
   }
 
-  Parser repeatTag() => someTag("repeat");
+  Parser repeatTag([LiquidConfig? config]) => someTag("repeat", config: config);
 
-  Parser repeatBlock() =>
+  Parser repeatBlock([LiquidConfig? config]) =>
       seq3(
-        ref0(repeatTag),
-        ref0(element).starLazy(endRepeatTag()),
-        ref0(endRepeatTag),
+        repeatTag(config),
+        ref0(element).starLazy(endRepeatTag(config)),
+        endRepeatTag(config),
       ).map((values) {
         return values.$1.copyWith(body: values.$2.cast<ASTNode>());
       });
 
-  Parser endRepeatTag() =>
-      (tagStart() & string('endrepeat').trim() & tagEnd()).map((values) {
-        return Tag('endrepeat', []);
-      });
+  Parser endRepeatTag([LiquidConfig? config]) =>
+      (createTagStart(config) &
+              string('endrepeat').trim() &
+              createTagEnd(config))
+          .map((values) {
+            return Tag('endrepeat', []);
+          });
 
   @override
-  Parser parser() => repeatBlock();
+  Parser parser([LiquidConfig? config]) => repeatBlock(config);
 }

--- a/pkgs/liquify/lib/src/tags/super_tag.dart
+++ b/pkgs/liquify/lib/src/tags/super_tag.dart
@@ -16,13 +16,13 @@ class SuperTag extends AbstractTag with CustomTagParser {
   TagDelimiterType get delimiterType => TagDelimiterType.variable;
 
   @override
-  Parser parser() {
-    // This matches syntax: {{ super() }}
-    return (varStart() &
+  Parser parser([LiquidConfig? config]) {
+    // This matches syntax: {{ super() }} or custom delimiters like [[ super() ]]
+    return (createVarStart(config) &
             string('super').trim() &
             char('(').trim() &
             char(')').trim() &
-            varEnd())
+            createVarEnd(config))
         .map((_) {
           return Tag('super', []);
         });

--- a/pkgs/liquify/lib/src/tags/super_tag.dart
+++ b/pkgs/liquify/lib/src/tags/super_tag.dart
@@ -13,6 +13,9 @@ class SuperTag extends AbstractTag with CustomTagParser {
   }
 
   @override
+  TagDelimiterType get delimiterType => TagDelimiterType.variable;
+
+  @override
   Parser parser() {
     // This matches syntax: {{ super() }}
     return (varStart() &

--- a/pkgs/liquify/lib/src/tags/tablerow.dart
+++ b/pkgs/liquify/lib/src/tags/tablerow.dart
@@ -297,10 +297,10 @@ class TableRowTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 
   @override
-  Parser parser() {
-    return (ref0(tableRowTag) &
-            any().plusLazy(endTableRowTag()) &
-            endTableRowTag())
+  Parser parser([LiquidConfig? config]) {
+    return (tableRowTag(config) &
+            any().plusLazy(endTableRowTag(config)) &
+            endTableRowTag(config))
         .map((values) {
           final tag = values[0] as Tag;
           tag.body = parseInput((values[1] as List).join(''));
@@ -309,9 +309,13 @@ class TableRowTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 }
 
-Parser tableRowTag() => someTag("tablerow");
+Parser tableRowTag([LiquidConfig? config]) =>
+    someTag("tablerow", config: config);
 
-Parser endTableRowTag() =>
-    (tagStart() & string('endtablerow').trim() & tagEnd()).map((values) {
-      return Tag('endtablerow', []);
-    });
+Parser endTableRowTag([LiquidConfig? config]) =>
+    (createTagStart(config) &
+            string('endtablerow').trim() &
+            createTagEnd(config))
+        .map((values) {
+          return Tag('endtablerow', []);
+        });

--- a/pkgs/liquify/lib/src/tags/tag.dart
+++ b/pkgs/liquify/lib/src/tags/tag.dart
@@ -13,6 +13,26 @@ mixin AsyncTag {
 }
 
 /// Abstract base class for all Liquid tags.
+///
+/// Subclass this to create custom tags. Override [evaluateWithContext] for
+/// synchronous evaluation or [evaluateWithContextAsync] for async evaluation.
+///
+/// ## Accessing Template Configuration
+///
+/// If your tag needs to re-parse content with the same delimiters as the parent
+/// template, access the config from the evaluator's context:
+///
+/// ```dart
+/// @override
+/// dynamic evaluateWithContext(Evaluator evaluator, Buffer buffer) {
+///   final config = evaluator.context.config;
+///   final liquid = Liquid(config: config ?? LiquidConfig.standard);
+///   final result = liquid.renderString(content, evaluator.context.all());
+///   buffer.write(result);
+/// }
+/// ```
+///
+/// See [Environment.config] for more details.
 abstract class AbstractTag {
   /// The content nodes of the tag.
   final List<ASTNode> content;

--- a/pkgs/liquify/lib/src/tags/unless.dart
+++ b/pkgs/liquify/lib/src/tags/unless.dart
@@ -67,10 +67,10 @@ class UnlessTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 
   @override
-  Parser parser() {
-    return (ref0(unlessTag).trim() &
-            any().plusLazy(endUnlessTag()) &
-            endUnlessTag())
+  Parser parser([LiquidConfig? config]) {
+    return (unlessTag(config).trim() &
+            any().plusLazy(endUnlessTag(config)) &
+            endUnlessTag(config))
         .map((values) {
           return (values[0] as Tag).copyWith(
             body: parseInput((values[1] as List).join('')),
@@ -79,9 +79,10 @@ class UnlessTag extends AbstractTag with CustomTagParser, AsyncTag {
   }
 }
 
-Parser unlessTag() => someTag("unless");
+Parser unlessTag([LiquidConfig? config]) => someTag("unless", config: config);
 
-Parser endUnlessTag() =>
-    (tagStart() & string('endunless').trim() & tagEnd()).map((values) {
-      return Tag('endunless', []);
-    });
+Parser endUnlessTag([LiquidConfig? config]) =>
+    (createTagStart(config) & string('endunless').trim() & createTagEnd(config))
+        .map((values) {
+          return Tag('endunless', []);
+        });

--- a/pkgs/liquify/pubspec.yaml
+++ b/pkgs/liquify/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   A powerful and extensible Liquid template engine for Dart.
   Supports full Liquid syntax, custom tags and filters, and high-performance parsing and rendering.
 
-version: 1.4.2
+version: 1.5.0
 
 repository: https://github.com/kingwill101/liquify
 

--- a/pkgs/liquify/test/custom_delimiters_test.dart
+++ b/pkgs/liquify/test/custom_delimiters_test.dart
@@ -1,0 +1,838 @@
+import 'package:liquify/liquify.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Custom Delimiters', () {
+    group('LiquidConfig', () {
+      test('creates default config with standard delimiters', () {
+        const config = LiquidConfig();
+        expect(config.tagStart, equals('{%'));
+        expect(config.tagEnd, equals('%}'));
+        expect(config.varStart, equals('{{'));
+        expect(config.varEnd, equals('}}'));
+        expect(config.stripMarker, equals('-'));
+      });
+
+      test('creates config with custom delimiters', () {
+        const config = LiquidConfig(
+          tagStart: '[%',
+          tagEnd: '%]',
+          varStart: '[[',
+          varEnd: ']]',
+        );
+        expect(config.tagStart, equals('[%'));
+        expect(config.tagEnd, equals('%]'));
+        expect(config.varStart, equals('[['));
+        expect(config.varEnd, equals(']]'));
+      });
+
+      test('computes strip variants correctly', () {
+        const config = LiquidConfig(
+          tagStart: '[%',
+          tagEnd: '%]',
+          varStart: '[[',
+          varEnd: ']]',
+        );
+        expect(config.tagStartStrip, equals('[%-'));
+        expect(config.tagEndStrip, equals('-%]'));
+        expect(config.varStartStrip, equals('[[-'));
+        expect(config.varEndStrip, equals('-]]'));
+      });
+
+      test('standard preset uses default delimiters', () {
+        expect(LiquidConfig.standard.tagStart, equals('{%'));
+        expect(LiquidConfig.standard.varStart, equals('{{'));
+      });
+
+      test('erb preset uses ERB-style delimiters', () {
+        expect(LiquidConfig.erb.tagStart, equals('<%'));
+        expect(LiquidConfig.erb.tagEnd, equals('%>'));
+        expect(LiquidConfig.erb.varStart, equals('<%='));
+        expect(LiquidConfig.erb.varEnd, equals('%>'));
+      });
+
+      test('copyWith creates modified copy', () {
+        const config = LiquidConfig();
+        final modified = config.copyWith(tagStart: '<%');
+        expect(modified.tagStart, equals('<%'));
+        expect(modified.tagEnd, equals('%}')); // unchanged
+        expect(modified.varStart, equals('{{')); // unchanged
+      });
+
+      test('equality works correctly', () {
+        const config1 = LiquidConfig(tagStart: '[%');
+        const config2 = LiquidConfig(tagStart: '[%');
+        const config3 = LiquidConfig(tagStart: '<%');
+
+        expect(config1, equals(config2));
+        expect(config1, isNot(equals(config3)));
+      });
+    });
+
+    group('Liquid with default delimiters', () {
+      late Liquid liquid;
+
+      setUp(() {
+        liquid = Liquid();
+      });
+
+      test('parses simple variable', () {
+        final template = liquid.parse('Hello {{ name }}!');
+        final result = template.render({'name': 'World'});
+        expect(result, equals('Hello World!'));
+      });
+
+      test('parses simple tag', () {
+        final template = liquid.parse('{% if show %}visible{% endif %}');
+        final result = template.render({'show': true});
+        expect(result, equals('visible'));
+      });
+
+      test('parses mixed content', () {
+        final template = liquid.parse(
+          '{% assign greeting = "Hello" %}{{ greeting }}, {{ name }}!',
+        );
+        final result = template.render({'name': 'World'});
+        expect(result, equals('Hello, World!'));
+      });
+    });
+
+    group('Liquid with custom delimiters', () {
+      late Liquid liquid;
+
+      setUp(() {
+        liquid = Liquid(
+          config: const LiquidConfig(
+            tagStart: '[%',
+            tagEnd: '%]',
+            varStart: '[[',
+            varEnd: ']]',
+          ),
+        );
+      });
+
+      test('parses simple variable with custom delimiters', () {
+        final template = liquid.parse('Hello [[ name ]]!');
+        final result = template.render({'name': 'World'});
+        expect(result, equals('Hello World!'));
+      });
+
+      test('parses simple tag with custom delimiters', () {
+        final template = liquid.parse('[% if show %]visible[% endif %]');
+        final result = template.render({'show': true});
+        expect(result, equals('visible'));
+      });
+
+      test('parses mixed content with custom delimiters', () {
+        final template = liquid.parse(
+          '[% assign greeting = "Hello" %][[ greeting ]], [[ name ]]!',
+        );
+        final result = template.render({'name': 'World'});
+        expect(result, equals('Hello, World!'));
+      });
+
+      test('parses for loop with custom delimiters', () {
+        final template = liquid.parse(
+          '[% for item in items %][[ item ]] [% endfor %]',
+        );
+        final result = template.render({
+          'items': ['a', 'b', 'c'],
+        });
+        expect(result, equals('a b c '));
+      });
+
+      test('parses filters with custom delimiters', () {
+        final template = liquid.parse('[[ name | upcase ]]');
+        final result = template.render({'name': 'hello'});
+        expect(result, equals('HELLO'));
+      });
+
+      test('standard delimiters do not work with custom config', () {
+        // {{ }} should be treated as plain text
+        final template = liquid.parse('Hello {{ name }}!');
+        final result = template.render({'name': 'World'});
+        // The {{ name }} should appear as literal text
+        expect(result, equals('Hello {{ name }}!'));
+      });
+    });
+
+    group('Liquid.withDelimiters convenience constructor', () {
+      test('creates liquid with custom delimiters', () {
+        final liquid = Liquid.withDelimiters(
+          tagStart: '<%',
+          tagEnd: '%>',
+          varStart: '<%=',
+          varEnd: '%>',
+        );
+
+        final template = liquid.parse('Hello <%= name %>!');
+        final result = template.render({'name': 'World'});
+        expect(result, equals('Hello World!'));
+      });
+    });
+
+    group('Whitespace stripping with custom delimiters', () {
+      late Liquid liquid;
+
+      setUp(() {
+        liquid = Liquid(
+          config: const LiquidConfig(
+            tagStart: '[%',
+            tagEnd: '%]',
+            varStart: '[[',
+            varEnd: ']]',
+          ),
+        );
+      });
+
+      test('[[-  strips preceding whitespace', () {
+        final template = liquid.parse('before [[- "hello" ]] after');
+        final result = template.render();
+        expect(result, equals('beforehello after'));
+      });
+
+      test('-]] strips following whitespace', () {
+        final template = liquid.parse('before [[ "hello" -]] after');
+        final result = template.render();
+        expect(result, equals('before helloafter'));
+      });
+
+      test('[%- strips preceding whitespace', () {
+        final template = liquid.parse(
+          'before [%- if true %]hello[% endif %] after',
+        );
+        final result = template.render();
+        expect(result, equals('beforehello after'));
+      });
+    });
+
+    group('ERB-style delimiters', () {
+      late Liquid liquid;
+
+      setUp(() {
+        liquid = Liquid(config: LiquidConfig.erb);
+      });
+
+      test('parses ERB-style template', () {
+        final template = liquid.parse('Hello <%= name %>!');
+        final result = template.render({'name': 'World'});
+        expect(result, equals('Hello World!'));
+      });
+
+      test('parses ERB-style control flow', () {
+        final template = liquid.parse('<% if show %>visible<% endif %>');
+        final result = template.render({'show': true});
+        expect(result, equals('visible'));
+      });
+    });
+
+    group('renderString convenience method', () {
+      test('parses and renders in one call', () {
+        final liquid = Liquid();
+        final result = liquid.renderString('Hello {{ name }}!', {
+          'name': 'World',
+        });
+        expect(result, equals('Hello World!'));
+      });
+
+      test('works with custom delimiters', () {
+        final liquid = Liquid(
+          config: const LiquidConfig(varStart: '[[', varEnd: ']]'),
+        );
+        final result = liquid.renderString('Hello [[ name ]]!', {
+          'name': 'World',
+        });
+        expect(result, equals('Hello World!'));
+      });
+    });
+
+    group('Multiple Liquid instances with different configs', () {
+      test('can coexist without interference', () {
+        final liquid1 = Liquid(); // default delimiters
+        final liquid2 = Liquid(
+          config: const LiquidConfig(varStart: '[[', varEnd: ']]'),
+        );
+
+        // Each should parse its own delimiter style
+        final result1 = liquid1.renderString('{{ name }}', {'name': 'A'});
+        final result2 = liquid2.renderString('[[ name ]]', {'name': 'B'});
+
+        expect(result1, equals('A'));
+        expect(result2, equals('B'));
+
+        // And not parse the other style
+        final result3 = liquid1.renderString('[[ name ]]', {'name': 'C'});
+        final result4 = liquid2.renderString('{{ name }}', {'name': 'D'});
+
+        expect(result3, equals('[[ name ]]')); // treated as text
+        expect(result4, equals('{{ name }}')); // treated as text
+      });
+    });
+
+    group('Edge cases', () {
+      test('handles empty template', () {
+        final liquid = Liquid();
+        final template = liquid.parse('');
+        final result = template.render();
+        expect(result, equals(''));
+      });
+
+      test('handles template with no delimiters', () {
+        final liquid = Liquid();
+        final template = liquid.parse('Just plain text');
+        final result = template.render();
+        expect(result, equals('Just plain text'));
+      });
+
+      test('handles delimiter-like text that is not a delimiter', () {
+        final liquid = Liquid(
+          config: const LiquidConfig(
+            tagStart: '[[',
+            tagEnd: ']]',
+            varStart: '[[[',
+            varEnd: ']]]',
+          ),
+        );
+        // A single [ or [[ should not trigger variable parsing
+        final template = liquid.parse('array[0] or [[tag]]');
+        final result = template.render();
+        // [[tag]] is a tag, but [0] is plain text
+        expect(result, contains('array[0]'));
+      });
+    });
+
+    group('Comprehensive ERB-style template', () {
+      late Liquid liquid;
+
+      setUp(() {
+        liquid = Liquid(config: LiquidConfig.erb);
+      });
+
+      test('variables and filters with ERB delimiters', () {
+        const template = '''
+=== VARIABLES AND FILTERS ===
+Name: <%= user.name | upcase %>
+Email: <%= user.email | downcase | strip %>
+Greeting: <%= "hello world" | capitalize | append: "!" %>
+''';
+
+        final result = liquid.renderString(template, {
+          'user': {'name': 'John Doe', 'email': '  JOHN@EXAMPLE.COM  '},
+        });
+
+        expect(result, contains('Name: JOHN DOE'));
+        expect(result, contains('Email: john@example.com'));
+        expect(result, contains('Greeting: Hello world!'));
+      });
+
+      test('assign and capture with ERB delimiters', () {
+        const template = '''
+<% assign title = "Dashboard" %>
+Title: <%= title %>
+<% capture full_greeting %>Hello from <%= title %><% endcapture %>
+<%= full_greeting %>
+''';
+
+        final result = liquid.renderString(template, {});
+
+        expect(result, contains('Title: Dashboard'));
+        expect(result, contains('Hello from Dashboard'));
+      });
+
+      test('if/elsif/else with ERB delimiters', () {
+        const template = '''
+<% if user.role == "admin" %>
+User is an admin
+<% elsif user.role == "moderator" %>
+User is a moderator
+<% else %>
+User is a regular member
+<% endif %>
+''';
+
+        final adminResult = liquid.renderString(template, {
+          'user': {'role': 'admin'},
+        });
+        expect(adminResult, contains('User is an admin'));
+
+        final modResult = liquid.renderString(template, {
+          'user': {'role': 'moderator'},
+        });
+        expect(modResult, contains('User is a moderator'));
+
+        final userResult = liquid.renderString(template, {
+          'user': {'role': 'user'},
+        });
+        expect(userResult, contains('User is a regular member'));
+      });
+
+      test('nested if blocks with ERB delimiters', () {
+        const template = '''
+<% if user.active %>
+  <% if user.verified %>
+Active and verified
+  <% else %>
+Active but not verified
+  <% endif %>
+<% endif %>
+''';
+
+        final result = liquid.renderString(template, {
+          'user': {'active': true, 'verified': true},
+        });
+        expect(result, contains('Active and verified'));
+      });
+
+      test('unless with ERB delimiters', () {
+        const template = '''
+<% unless user.banned %>
+User is not banned
+<% endunless %>
+''';
+
+        final result = liquid.renderString(template, {
+          'user': {'banned': false},
+        });
+        expect(result, contains('User is not banned'));
+      });
+
+      test('for loop with forloop object using ERB delimiters', () {
+        const template = '''
+<% for item in items %>
+[<%= forloop.index %>/<%= forloop.length %>] <%= item %><% if forloop.first %> (FIRST)<% endif %><% if forloop.last %> (LAST)<% endif %>
+<% endfor %>
+''';
+
+        final result = liquid.renderString(template, {
+          'items': ['Apple', 'Banana', 'Cherry'],
+        });
+
+        expect(result, contains('[1/3] Apple (FIRST)'));
+        expect(result, contains('[2/3] Banana'));
+        expect(result, contains('[3/3] Cherry (LAST)'));
+      });
+
+      test('for loop with limit using ERB delimiters', () {
+        const template =
+            '<% for item in items limit:2 %><%= item %> <% endfor %>';
+
+        final result = liquid.renderString(template, {
+          'items': ['A', 'B', 'C', 'D'],
+        });
+
+        expect(result, contains('A'));
+        expect(result, contains('B'));
+        expect(result, isNot(contains('C')));
+      });
+
+      test('for loop with range using ERB delimiters', () {
+        const template =
+            '<% for i in (1..5) %><%= i %><% unless forloop.last %>,<% endunless %><% endfor %>';
+
+        final result = liquid.renderString(template, {});
+
+        expect(result, equals('1,2,3,4,5'));
+      });
+
+      test('for-else with ERB delimiters', () {
+        const template = '''
+<% for item in items %>
+- <%= item %>
+<% else %>
+No items found!
+<% endfor %>
+''';
+
+        final emptyResult = liquid.renderString(template, {'items': []});
+        expect(emptyResult, contains('No items found!'));
+
+        final withItemsResult = liquid.renderString(template, {
+          'items': ['Apple'],
+        });
+        expect(withItemsResult, contains('- Apple'));
+      });
+
+      test('case/when/else with ERB delimiters', () {
+        const template = '''
+<% case status %>
+<% when "online" %>
+User is online
+<% when "away" %>
+User is away
+<% else %>
+Unknown status
+<% endcase %>
+''';
+
+        final onlineResult = liquid.renderString(template, {
+          'status': 'online',
+        });
+        expect(onlineResult, contains('User is online'));
+
+        final awayResult = liquid.renderString(template, {'status': 'away'});
+        expect(awayResult, contains('User is away'));
+
+        final unknownResult = liquid.renderString(template, {
+          'status': 'offline',
+        });
+        expect(unknownResult, contains('Unknown status'));
+      });
+
+      test('increment/decrement with ERB delimiters', () {
+        const template =
+            '<% increment counter %>,<% increment counter %>,<% increment counter %>';
+
+        final result = liquid.renderString(template, {});
+        expect(result, contains('0'));
+        expect(result, contains('1'));
+        expect(result, contains('2'));
+      });
+
+      test('complex expressions with ERB delimiters', () {
+        const template = '''
+<% if count > 0 and active == true %>
+Count is positive and active
+<% endif %>
+<% if count >= 5 or role == "admin" %>
+Count >= 5 or admin
+<% endif %>
+''';
+
+        final result = liquid.renderString(template, {
+          'count': 10,
+          'active': true,
+          'role': 'user',
+        });
+
+        expect(result, contains('Count is positive and active'));
+        expect(result, contains('Count >= 5 or admin'));
+      });
+
+      test('array access with ERB delimiters', () {
+        const template = '''
+First: <%= items[0] %>
+Second: <%= items[1] %>
+''';
+
+        final result = liquid.renderString(template, {
+          'items': ['Apple', 'Banana', 'Cherry'],
+        });
+
+        expect(result, contains('First: Apple'));
+        expect(result, contains('Second: Banana'));
+      });
+
+      test('contains operator with ERB delimiters', () {
+        const template = '''
+<% if name contains "John" %>
+Name contains John
+<% endif %>
+<% assign colors = "red,green,blue" %>
+<% if colors contains "green" %>
+Has green
+<% endif %>
+''';
+
+        final result = liquid.renderString(template, {'name': 'John Doe'});
+        expect(result, contains('Name contains John'));
+        expect(result, contains('Has green'));
+      });
+
+      test('multiple filters chained with ERB delimiters', () {
+        const template =
+            '<%= "  hello world  " | strip | upcase | prepend: ">>> " | append: " <<<" %>';
+
+        final result = liquid.renderString(template, {});
+        expect(result, contains('>>> HELLO WORLD <<<'));
+      });
+
+      test('whitespace control with ERB delimiters', () {
+        // Test whitespace stripping with tag delimiters
+        const template = 'Before <% if true -%> middle <% endif %> After';
+
+        final result = liquid.renderString(template, {});
+        expect(result, contains('Before'));
+        expect(result, contains('middle'));
+        expect(result, contains('After'));
+      });
+
+      test('cycle with ERB delimiters', () {
+        const template =
+            '<% for i in (1..4) %><% cycle "odd", "even" %><% endfor %>';
+
+        final result = liquid.renderString(template, {});
+        expect(result, contains('odd'));
+        expect(result, contains('even'));
+      });
+
+      test('comment tag with ERB delimiters', () {
+        const template =
+            'Before<% comment %>This should not appear<% endcomment %>After';
+
+        final result = liquid.renderString(template, {});
+        expect(result, contains('BeforeAfter'));
+        expect(result, isNot(contains('This should not appear')));
+      });
+
+      test('handles deeply nested control structures', () {
+        const template = '''
+<% for category in categories %>
+Category: <%= category.name %>
+  <% for product in category.products %>
+    <% if product.in_stock %>
+      <% case product.rating %>
+      <% when 5 %>
+        ★★★★★ <%= product.name %>
+      <% when 4 %>
+        ★★★★☆ <%= product.name %>
+      <% when 3 %>
+        ★★★☆☆ <%= product.name %>
+      <% else %>
+        ★★☆☆☆ <%= product.name %> (low rating)
+      <% endcase %>
+    <% else %>
+      [OUT OF STOCK] <%= product.name %>
+    <% endif %>
+  <% endfor %>
+<% endfor %>
+''';
+
+        final result = liquid.renderString(template, {
+          'categories': [
+            {
+              'name': 'Electronics',
+              'products': [
+                {'name': 'Phone', 'in_stock': true, 'rating': 5},
+                {'name': 'Tablet', 'in_stock': true, 'rating': 4},
+                {'name': 'Laptop', 'in_stock': false, 'rating': 5},
+              ],
+            },
+            {
+              'name': 'Books',
+              'products': [
+                {'name': 'Fiction', 'in_stock': true, 'rating': 3},
+                {'name': 'Non-fiction', 'in_stock': true, 'rating': 2},
+              ],
+            },
+          ],
+        });
+
+        expect(result, contains('Category: Electronics'));
+        expect(result, contains('★★★★★ Phone'));
+        expect(result, contains('★★★★☆ Tablet'));
+        expect(result, contains('[OUT OF STOCK] Laptop'));
+        expect(result, contains('Category: Books'));
+        expect(result, contains('★★★☆☆ Fiction'));
+        expect(result, contains('(low rating)'));
+      });
+
+      test('handles complex filter chains', () {
+        const template = '''
+<%= items | map: "name" | join: ", " %>
+<%= items | first | map: "name" %>
+<%= items | last | map: "name" %>
+<%= items | size %>
+<%= "hello" | slice: 0, 3 | upcase %>
+<%= 1234.5678 | round: 2 %>
+<%= "hello world" | split: " " | first | capitalize %>
+<%= "2024-01-15" | date: "%B %d, %Y" %>
+''';
+
+        final result = liquid.renderString(template, {
+          'items': [
+            {'name': 'Alpha'},
+            {'name': 'Beta'},
+            {'name': 'Gamma'},
+          ],
+        });
+
+        expect(result, contains('Alpha, Beta, Gamma'));
+        expect(result, contains('3'));
+        expect(result, contains('HEL'));
+        expect(result, contains('1234.57'));
+        expect(result, contains('Hello'));
+      });
+
+      test('handles break and continue in loops', () {
+        const template = '''
+<% for i in (1..10) %>
+<% if i == 3 %><% continue %><% endif %>
+<% if i == 6 %><% break %><% endif %>
+<%= i %>
+<% endfor %>
+''';
+
+        final result = liquid.renderString(template, {});
+
+        expect(result, contains('1'));
+        expect(result, contains('2'));
+        expect(result, isNot(contains('3'))); // skipped by continue
+        expect(result, contains('4'));
+        expect(result, contains('5'));
+        expect(result, isNot(contains('6'))); // stopped by break
+        expect(result, isNot(contains('7'))); // after break
+      });
+
+      test('handles arithmetic operations', () {
+        const template = '''
+<% assign a = 10 %>
+<% assign b = 3 %>
+<%= a | plus: b %>
+<%= a | minus: b %>
+<%= a | times: b %>
+<%= a | divided_by: b %>
+<%= a | modulo: b %>
+''';
+
+        final result = liquid.renderString(template, {});
+
+        expect(result, contains('13')); // 10 + 3
+        expect(result, contains('7')); // 10 - 3
+        expect(result, contains('30')); // 10 * 3
+        // divided_by with integers gives integer result
+      });
+
+      test('handles string filters', () {
+        const template = '''
+<%= "hello" | append: " world" %>
+<%= "world" | prepend: "hello " %>
+<%= "hello world" | remove: "world" %>
+<%= "hello world" | remove_first: "l" %>
+<%= "hello world" | replace: "world", "universe" %>
+<%= "hello world" | replace_first: "l", "L" %>
+<%= "hello world" | truncate: 8 %>
+<%= "hello world" | truncatewords: 1 %>
+<%= "Hello World" | downcase %>
+<%= "hello world" | upcase %>
+<%= "hello world" | capitalize %>
+<%= "  hello  " | strip %>
+<%= "  hello  " | lstrip %>
+<%= "  hello  " | rstrip %>
+<%= "hello\nworld" | newline_to_br %>
+<%= "<p>hello</p>" | strip_html %>
+<%= "hello world" | size %>
+''';
+
+        final result = liquid.renderString(template, {});
+
+        expect(result, contains('hello world'));
+        expect(result, contains('hello universe'));
+        expect(result, contains('hello '));
+        expect(result, contains('heLlo world'));
+        expect(result, contains('hello...'));
+        expect(result, contains('HELLO WORLD'));
+        expect(result, contains('Hello world'));
+        expect(result, contains('11')); // size
+      });
+
+      test('handles array filters', () {
+        const template = '''
+<%= items | join: "-" %>
+<%= items | first %>
+<%= items | last %>
+<%= items | reverse | join: "-" %>
+<%= items | sort | join: "-" %>
+<%= items | uniq | join: "-" %>
+<%= items | compact | join: "-" %>
+<%= items | size %>
+''';
+
+        final result = liquid.renderString(template, {
+          'items': ['c', 'a', 'b', 'a'],
+        });
+
+        expect(result, contains('c-a-b-a'));
+        expect(result, contains('a-b-a-c')); // reverse
+        expect(result, contains('a-a-b-c')); // sort
+        expect(result, contains('c-a-b')); // uniq
+        expect(result, contains('4')); // size
+      });
+
+      test('handles default filter', () {
+        // Test default filter with missing value
+        final result1 = liquid.renderString(
+          '<%= missing | default: "not found" %>',
+          {},
+        );
+        expect(result1, equals('not found'));
+
+        // Test default filter with actual value
+        final result2 = liquid.renderString(
+          '<%= actual | default: "fallback" %>',
+          {'actual': 'real'},
+        );
+        expect(result2, equals('real'));
+      });
+    });
+
+    group('Template.parse with custom delimiters', () {
+      test('parses simple variable with custom delimiters', () {
+        final template = Template.parse(
+          'Hello [[ name ]]!',
+          config: const LiquidConfig(varStart: '[[', varEnd: ']]'),
+          data: {'name': 'World'},
+        );
+        expect(template.render(), equals('Hello World!'));
+      });
+
+      test('parses simple tag with custom delimiters', () {
+        final template = Template.parse(
+          '[% if show %]visible[% endif %]',
+          config: const LiquidConfig(tagStart: '[%', tagEnd: '%]'),
+          data: {'show': true},
+        );
+        expect(template.render(), equals('visible'));
+      });
+
+      test('parses mixed content with custom delimiters', () {
+        final template = Template.parse(
+          '[% if user %]Hello [[ name ]]![% endif %]',
+          config: const LiquidConfig(
+            tagStart: '[%',
+            tagEnd: '%]',
+            varStart: '[[',
+            varEnd: ']]',
+          ),
+          data: {'user': true, 'name': 'Alice'},
+        );
+        expect(template.render(), equals('Hello Alice!'));
+      });
+
+      test('parses for loop with custom delimiters', () {
+        final template = Template.parse(
+          '[% for item in items %][[ item ]][% endfor %]',
+          config: const LiquidConfig(
+            tagStart: '[%',
+            tagEnd: '%]',
+            varStart: '[[',
+            varEnd: ']]',
+          ),
+          data: {
+            'items': ['a', 'b', 'c'],
+          },
+        );
+        expect(template.render(), equals('abc'));
+      });
+
+      test('standard delimiters do not work with custom config', () {
+        final template = Template.parse(
+          'Hello {{ name }}!',
+          config: const LiquidConfig(varStart: '[[', varEnd: ']]'),
+          data: {'name': 'World'},
+        );
+        // {{ name }} should be treated as plain text
+        expect(template.render(), equals('Hello {{ name }}!'));
+      });
+
+      test('async rendering works with custom delimiters', () async {
+        final template = Template.parse(
+          'Hello [[ name ]]!',
+          config: const LiquidConfig(varStart: '[[', varEnd: ']]'),
+          data: {'name': 'World'},
+        );
+        final result = await template.renderAsync();
+        expect(result, equals('Hello World!'));
+      });
+    });
+  });
+}

--- a/pkgs/liquify/test/filters/filter_performance_benchmark_test.dart
+++ b/pkgs/liquify/test/filters/filter_performance_benchmark_test.dart
@@ -1,7 +1,6 @@
 import 'package:test/test.dart';
 import 'package:liquify/liquify.dart';
 import 'package:liquify/parser.dart' show parseInput;
-import 'package:liquify/src/context.dart';
 import 'package:liquify/src/evaluator.dart';
 
 /// Uncached version of expression evaluation for comparison
@@ -124,9 +123,7 @@ void main() {
       }
 
       // Cached: reuse RegExp
-      int cachedComparisons = 0;
       int cachedCompare(dynamic a, dynamic b) {
-        cachedComparisons++;
         String aStr = a.toString();
         String bStr = b.toString();
         // Reuse cached RegExp

--- a/pkgs/liquify/test/filters/filter_performance_benchmark_test.dart
+++ b/pkgs/liquify/test/filters/filter_performance_benchmark_test.dart
@@ -1,0 +1,205 @@
+import 'package:test/test.dart';
+import 'package:liquify/liquify.dart';
+import 'package:liquify/parser.dart' show parseInput;
+import 'package:liquify/src/context.dart';
+import 'package:liquify/src/evaluator.dart';
+
+/// Uncached version of expression evaluation for comparison
+dynamic _evaluateLiquidExpressionUncached(
+  dynamic item,
+  String itemName,
+  String expression,
+) {
+  try {
+    final liquidExpression = '{{ $expression }}';
+    // Always parse - no caching
+    final parsed = parseInput(liquidExpression);
+    if (parsed.isEmpty) return false;
+
+    final context = Environment();
+    if (item is Map) {
+      context.setVariable(itemName, item);
+      for (final entry in item.entries) {
+        if (entry.key is String) {
+          context.setVariable(entry.key as String, entry.value);
+        }
+      }
+    } else {
+      context.setVariable(itemName, item);
+    }
+
+    final evaluator = Evaluator(context);
+    final result = evaluator.evaluate(parsed.first);
+
+    if (result == null || result == false) return false;
+    if (result == true) return true;
+    if (result is String && result.isEmpty) return false;
+    if (result is num && result == 0) return false;
+    if (result is List && result.isEmpty) return false;
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+void main() {
+  group('Filter Performance Benchmarks - Cached vs Uncached', () {
+    test('where_exp: Cached vs Uncached expression parsing', () {
+      final products = List.generate(
+        500,
+        (i) => {'name': 'Product $i', 'price': i * 10, 'active': i % 2 == 0},
+      );
+
+      print('\n=== where_exp Expression Parsing: Cached vs Uncached ===');
+
+      // Uncached: parse expression for EVERY item
+      final swUncached = Stopwatch()..start();
+      for (var run = 0; run < 10; run++) {
+        final filtered = products.where((item) {
+          return _evaluateLiquidExpressionUncached(
+            item,
+            'item',
+            'item.active == true',
+          );
+        }).toList();
+        expect(filtered.length, equals(250));
+      }
+      swUncached.stop();
+
+      // Cached: use Template which uses the cached version
+      final whereExpTemplate = Template.parse(
+        "{{ products | where_exp: 'item', 'item.active == true' | size }}",
+        data: {'products': products},
+      );
+      whereExpTemplate.render(); // warmup
+
+      final swCached = Stopwatch()..start();
+      for (var run = 0; run < 10; run++) {
+        final result = whereExpTemplate.render();
+        expect(result, equals('250'));
+      }
+      swCached.stop();
+
+      final uncachedMs = swUncached.elapsedMilliseconds;
+      final cachedMs = swCached.elapsedMilliseconds;
+      final speedup = uncachedMs / cachedMs;
+
+      print('500 items x 10 runs:');
+      print('  Uncached: ${uncachedMs}ms (parses expression 5000 times)');
+      print('  Cached:   ${cachedMs}ms (parses expression once)');
+      print('  Speedup:  ${speedup.toStringAsFixed(1)}x faster');
+
+      // Cached should be significantly faster
+      expect(cachedMs, lessThan(uncachedMs));
+    });
+
+    test('sort_natural: RegExp caching impact', () {
+      final items = List.generate(500, (i) => 'item${i % 50}');
+      final regex = RegExp(r'^(.*?)(\d+)(.*)$');
+
+      print('\n=== sort_natural RegExp: Cached vs Uncached ===');
+
+      // Uncached: create new RegExp for each comparison
+      int uncachedComparisons = 0;
+      int uncachedCompare(dynamic a, dynamic b) {
+        uncachedComparisons++;
+        String aStr = a.toString();
+        String bStr = b.toString();
+        // Create NEW RegExp each time (what old code did)
+        final aMatch = RegExp(r'^(.*?)(\d+)(.*)$').firstMatch(aStr);
+        final bMatch = RegExp(r'^(.*?)(\d+)(.*)$').firstMatch(bStr);
+
+        if (aMatch != null && bMatch != null) {
+          int prefixCmp = (aMatch.group(1) ?? '').compareTo(
+            bMatch.group(1) ?? '',
+          );
+          if (prefixCmp != 0) return prefixCmp;
+          int aNum = int.tryParse(aMatch.group(2) ?? '0') ?? 0;
+          int bNum = int.tryParse(bMatch.group(2) ?? '0') ?? 0;
+          int numCmp = aNum.compareTo(bNum);
+          if (numCmp != 0) return numCmp;
+          return (aMatch.group(3) ?? '').compareTo(bMatch.group(3) ?? '');
+        }
+        return aStr.compareTo(bStr);
+      }
+
+      // Cached: reuse RegExp
+      int cachedComparisons = 0;
+      int cachedCompare(dynamic a, dynamic b) {
+        cachedComparisons++;
+        String aStr = a.toString();
+        String bStr = b.toString();
+        // Reuse cached RegExp
+        final aMatch = regex.firstMatch(aStr);
+        final bMatch = regex.firstMatch(bStr);
+
+        if (aMatch != null && bMatch != null) {
+          int prefixCmp = (aMatch.group(1) ?? '').compareTo(
+            bMatch.group(1) ?? '',
+          );
+          if (prefixCmp != 0) return prefixCmp;
+          int aNum = int.tryParse(aMatch.group(2) ?? '0') ?? 0;
+          int bNum = int.tryParse(bMatch.group(2) ?? '0') ?? 0;
+          int numCmp = aNum.compareTo(bNum);
+          if (numCmp != 0) return numCmp;
+          return (aMatch.group(3) ?? '').compareTo(bMatch.group(3) ?? '');
+        }
+        return aStr.compareTo(bStr);
+      }
+
+      final swUncached = Stopwatch()..start();
+      for (var run = 0; run < 100; run++) {
+        final sorted = List.from(items);
+        sorted.sort(uncachedCompare);
+      }
+      swUncached.stop();
+
+      final swCached = Stopwatch()..start();
+      for (var run = 0; run < 100; run++) {
+        final sorted = List.from(items);
+        sorted.sort(cachedCompare);
+      }
+      swCached.stop();
+
+      final uncachedMs = swUncached.elapsedMilliseconds;
+      final cachedMs = swCached.elapsedMilliseconds;
+      final speedup = uncachedMs / cachedMs;
+
+      print('500 items x 100 sorts:');
+      print(
+        '  Uncached: ${uncachedMs}ms (creates ~${uncachedComparisons * 2} RegExp objects)',
+      );
+      print('  Cached:   ${cachedMs}ms (reuses 1 RegExp)');
+      print('  Speedup:  ${speedup.toStringAsFixed(1)}x faster');
+      print('  Comparisons per sort: ${uncachedComparisons ~/ 100}');
+
+      expect(cachedMs, lessThan(uncachedMs));
+    });
+
+    test('Summary: Filter caching benchmark results', () {
+      print('\n');
+      print('=' * 60);
+      print('FILTER CACHING OPTIMIZATION SUMMARY');
+      print('=' * 60);
+      print('');
+      print('Optimizations implemented:');
+      print('  1. Expression parsing cache for *_exp filters');
+      print('     - where_exp, find_exp, group_by_exp, reject_exp, etc.');
+      print('     - Parses expression ONCE per unique expression string');
+      print('     - Previously: parsed for EVERY array item');
+      print('');
+      print('  2. Natural sort RegExp cache');
+      print('     - Single RegExp instance reused across all comparisons');
+      print('     - Previously: created 2 RegExp per comparison');
+      print('');
+      print('  3. String filter RegExp cache');
+      print('     - Cached: whitespace, newline, CJK patterns');
+      print('     - Used by: truncatewords, strip_newlines,');
+      print('       normalize_whitespace, number_of_words');
+      print('');
+      print('  4. Unified filter registry lookup cache');
+      print('     - O(1) filter lookup instead of iterating modules');
+      print('=' * 60);
+    });
+  });
+}

--- a/pkgs/liquify/test/layout/analyzer/layout_analyzer_issues_test.dart
+++ b/pkgs/liquify/test/layout/analyzer/layout_analyzer_issues_test.dart
@@ -559,18 +559,18 @@ This content will be lost!
         );
       });
 
-      test('inheritanceChain returns new list instance each time', () {
+      test('inheritanceChain returns cached list instance', () {
         final analysis = analyzer.analyzeTemplate('level5.liquid').last;
         final structure = analysis.structures['level5.liquid']!;
 
         final chain1 = structure.inheritanceChain;
         final chain2 = structure.inheritanceChain;
 
-        // Currently creates new list each time
+        // Now cached - returns same instance
         expect(
           identical(chain1, chain2),
-          isFalse,
-          reason: 'inheritanceChain creates new list on each access',
+          isTrue,
+          reason: 'inheritanceChain should return cached list',
         );
 
         // Content should be the same

--- a/pkgs/liquify/test/layout/analyzer/layout_analyzer_issues_test.dart
+++ b/pkgs/liquify/test/layout/analyzer/layout_analyzer_issues_test.dart
@@ -1,0 +1,804 @@
+/// Tests to validate and document issues in the layout analyzer system.
+///
+/// These tests are designed to:
+/// 1. Document known issues with failing tests
+/// 2. Validate fixes once implemented
+/// 3. Prevent regressions
+///
+/// Test categories:
+/// - Critical Issues: Bugs that cause incorrect behavior
+/// - Performance Issues: Inefficiencies that affect speed
+/// - Logic Issues: Edge cases not properly handled
+/// - Memory Issues: Resource leaks or circular references
+
+import 'package:liquify/parser.dart';
+import 'package:liquify/src/analyzer/block_info.dart';
+import 'package:liquify/src/analyzer/resolver.dart';
+import 'package:liquify/src/analyzer/template_analyzer.dart';
+import 'package:liquify/src/analyzer/template_structure.dart';
+import 'package:liquify/src/util.dart';
+import 'package:test/test.dart';
+
+import '../../shared_test_root.dart';
+
+void main() {
+  // Disable logging for cleaner test output
+  Logger.disableAllContexts();
+
+  group('Critical Issues', () {
+    group('Hardcoded nav tag check (resolver.dart:208)', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+      });
+
+      test('super() should work with any tag type, not just nav', () {
+        // Base template with a sidebar block containing a menu tag
+        root.addFile('base.liquid', '''
+<div>
+{% block sidebar %}
+<menu>
+<li>Home</li>
+<li>About</li>
+</menu>
+{% endblock %}
+</div>
+''');
+
+        // Child template overrides sidebar and uses super()
+        root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block sidebar %}
+<div class="custom-sidebar">
+{{ super() }}
+<li>Contact</li>
+</div>
+{% endblock %}
+''');
+
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final structure = analysis.structures['child.liquid']!;
+        final mergedAst = buildCompleteMergedAst(structure);
+
+        // Convert AST to string for easier validation
+        final output = _astToString(mergedAst);
+
+        // The parent's menu content should be included via super()
+        expect(
+          output,
+          contains('Home'),
+          reason: 'super() should include parent content',
+        );
+        expect(
+          output,
+          contains('About'),
+          reason: 'super() should include parent content',
+        );
+        expect(
+          output,
+          contains('Contact'),
+          reason: 'Child content should be present',
+        );
+      });
+
+      test('super() should work with div tags', () {
+        root.addFile('base.liquid', '''
+{% block content %}
+<div class="base-content">
+Base content here
+</div>
+{% endblock %}
+''');
+
+        root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block content %}
+<wrapper>
+{{ super() }}
+<p>Additional child content</p>
+</wrapper>
+{% endblock %}
+''');
+
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final structure = analysis.structures['child.liquid']!;
+        final mergedAst = buildCompleteMergedAst(structure);
+
+        final output = _astToString(mergedAst);
+
+        expect(
+          output,
+          contains('Base content here'),
+          reason: 'super() should work with div tags, not just nav',
+        );
+        expect(output, contains('Additional child content'));
+      });
+
+      test('super() should work with custom component tags', () {
+        root.addFile('base.liquid', '''
+{% block widget %}
+<my-custom-component>
+Widget default content
+</my-custom-component>
+{% endblock %}
+''');
+
+        root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block widget %}
+{{ super() }}
+<my-custom-component>Extra widget</my-custom-component>
+{% endblock %}
+''');
+
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final structure = analysis.structures['child.liquid']!;
+        final mergedAst = buildCompleteMergedAst(structure);
+
+        final output = _astToString(mergedAst);
+
+        expect(
+          output,
+          contains('Widget default content'),
+          reason: 'super() should work with custom tags',
+        );
+        expect(output, contains('Extra widget'));
+      });
+    });
+
+    group('Silent content loss (resolver.dart:101-103, 122-124)', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+      });
+
+      test('super() in root template should warn or handle gracefully', () {
+        // A standalone template (no parent) that mistakenly uses super()
+        root.addFile('standalone.liquid', '''
+{% block content %}
+{{ super() }}
+This is standalone content
+{% endblock %}
+''');
+
+        final analysis = analyzer.analyzeTemplate('standalone.liquid').last;
+        final structure = analysis.structures['standalone.liquid']!;
+        final mergedAst = buildCompleteMergedAst(structure);
+
+        final output = _astToString(mergedAst);
+
+        // At minimum, the non-super content should be preserved
+        expect(
+          output,
+          contains('This is standalone content'),
+          reason: 'Content after super() should not be lost',
+        );
+
+        // Ideally, there should be a warning about super() in root template
+        // This is currently not implemented - super() silently returns empty
+      });
+
+      test('blocks defined in child but not in parent are silently discarded', () {
+        root.addFile('base.liquid', '''
+{% block header %}Header{% endblock %}
+{% block footer %}Footer{% endblock %}
+''');
+
+        // Child defines a NEW block that doesn't exist in parent
+        // This is a common mistake - user expects the block to appear somewhere
+        root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block nonexistent %}
+This content will be lost!
+{% endblock %}
+''');
+
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final structure = analysis.structures['child.liquid']!;
+
+        // The block IS in the child's structure
+        expect(
+          structure.blocks.containsKey('nonexistent'),
+          isTrue,
+          reason: 'Block should be tracked in child structure',
+        );
+
+        // FIXED: Block is now correctly marked as NOT an override
+        final nonexistent = structure.blocks['nonexistent']!;
+        expect(
+          nonexistent.isOverride,
+          isFalse,
+          reason:
+              'Block that does not exist in parent should not be marked as override',
+        );
+
+        // The content is still lost because base.liquid has no 'nonexistent' block
+        // This is expected behavior for layout inheritance - child can only override
+        // blocks that exist in the parent, not create new ones
+        final mergedAst = buildCompleteMergedAst(structure);
+        final output = _astToString(mergedAst);
+
+        expect(
+          output,
+          isNot(contains('This content will be lost')),
+          reason:
+              'Content is not rendered because parent has no corresponding block (expected behavior)',
+        );
+      });
+
+      test(
+        'isOverride should be false for blocks that do not exist in parent',
+        () {
+          root.addFile('base.liquid', '''
+{% block existing %}Base content{% endblock %}
+''');
+
+          root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block existing %}Override content{% endblock %}
+{% block new_block %}New content{% endblock %}
+''');
+
+          final analysis = analyzer.analyzeTemplate('child.liquid').last;
+          final structure = analysis.structures['child.liquid']!;
+
+          // 'existing' should be marked as override
+          final existing = structure.blocks['existing']!;
+          expect(
+            existing.isOverride,
+            isTrue,
+            reason: 'Block that exists in parent should be marked as override',
+          );
+
+          // FIXED: 'new_block' should NOT be marked as override
+          final newBlock = structure.blocks['new_block']!;
+          expect(
+            newBlock.isOverride,
+            isFalse,
+            reason:
+                'Block that does NOT exist in parent should NOT be marked as override',
+          );
+        },
+      );
+    });
+  });
+
+  group('Logic Issues', () {
+    group(
+      'Only handles Literal for parent path (template_analyzer.dart:130-131)',
+      () {
+        late TestRoot root;
+        late TemplateAnalyzer analyzer;
+
+        setUp(() {
+          root = TestRoot();
+          analyzer = TemplateAnalyzer(root);
+        });
+
+        test('layout tag with string literal path works', () {
+          root.addFile('base.liquid', '{% block content %}Base{% endblock %}');
+          root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block content %}Child{% endblock %}
+''');
+
+          final analysis = analyzer.analyzeTemplate('child.liquid').last;
+          expect(analysis.structures.containsKey('child.liquid'), isTrue);
+          expect(analysis.structures['child.liquid']!.parent, isNotNull);
+        });
+
+        // Note: Variable-based layout paths would require runtime resolution
+        // This test documents the current limitation
+        test('layout tag only supports literal paths (documented limitation)', () {
+          // This is expected behavior - variable paths need runtime resolution
+          // Just documenting that this is a known limitation
+          root.addFile('base.liquid', '{% block content %}Base{% endblock %}');
+
+          // Using a variable for the layout path won't work at analysis time
+          // This would require: {% assign template = 'base.liquid' %}{% layout template %}
+          // The analyzer only handles literal strings
+          expect(
+            true,
+            isTrue,
+            reason: 'Variable layout paths require runtime resolution',
+          );
+        });
+      },
+    );
+
+    group('Mutable map in const constructor (template_structure.dart:54)', () {
+      test('addBlock mutates supposedly immutable structure', () {
+        final blocks = <String, BlockInfo>{};
+        final structure = TemplateStructure(
+          templatePath: 'test.liquid',
+          nodes: [],
+          blocks: blocks,
+        );
+
+        // This mutation affects both the original map and the structure
+        structure.addBlock(
+          'test',
+          BlockInfo(
+            name: 'test',
+            source: 'test.liquid',
+            isOverride: false,
+            nestedBlocks: {},
+            hasSuperCall: false,
+          ),
+        );
+
+        // Both should now have the block (demonstrating shared mutable state)
+        expect(structure.blocks.containsKey('test'), isTrue);
+        expect(
+          blocks.containsKey('test'),
+          isTrue,
+          reason: 'Mutation affects original map - violates immutability',
+        );
+      });
+
+      test('external modification of blocks map affects structure', () {
+        final blocks = <String, BlockInfo>{
+          'initial': BlockInfo(
+            name: 'initial',
+            source: 'test.liquid',
+            isOverride: false,
+            nestedBlocks: {},
+            hasSuperCall: false,
+          ),
+        };
+
+        final structure = TemplateStructure(
+          templatePath: 'test.liquid',
+          nodes: [],
+          blocks: blocks,
+        );
+
+        // External modification
+        blocks['external'] = BlockInfo(
+          name: 'external',
+          source: 'external.liquid',
+          isOverride: false,
+          nestedBlocks: {},
+          hasSuperCall: false,
+        );
+
+        // The structure now has a block it shouldn't
+        expect(
+          structure.blocks.containsKey('external'),
+          isTrue,
+          reason:
+              'External modification affects structure - violates encapsulation',
+        );
+      });
+    });
+
+    group('deepCopy creates inherited block (block_info.dart:158)', () {
+      test(
+        'deepCopy parent points to original (intentional for inheritance)',
+        () {
+          final original = BlockInfo(
+            name: 'header',
+            source: 'base.liquid',
+            content: [TextNode('Original content')],
+            isOverride: false,
+            nestedBlocks: {},
+            hasSuperCall: false,
+          );
+
+          final copy = original.deepCopy('child.liquid');
+
+          // This is intentional - the copy represents the inherited version
+          // and its parent should point to the original for super() calls
+          expect(
+            copy.parent,
+            same(original),
+            reason: 'deepCopy sets parent to original for inheritance chain',
+          );
+
+          expect(copy.source, equals('child.liquid'));
+          expect(
+            copy.parent?.source,
+            equals('base.liquid'),
+            reason: 'Parent references original source for super() resolution',
+          );
+        },
+      );
+
+      test(
+        'deepCopy sets isOverride to false (intentional for inheritance)',
+        () {
+          final original = BlockInfo(
+            name: 'header',
+            source: 'base.liquid',
+            content: [TextNode('Content')],
+            isOverride: true, // Original is an override
+            nestedBlocks: {},
+            hasSuperCall: true,
+          );
+
+          final copy = original.deepCopy('child.liquid');
+
+          // This is intentional - the inherited version is NOT an override
+          // until the child template explicitly overrides it
+          expect(
+            copy.isOverride,
+            isFalse,
+            reason:
+                'Inherited block is not an override until explicitly overridden',
+          );
+
+          // hasSuperCall is preserved
+          expect(copy.hasSuperCall, isTrue);
+        },
+      );
+    });
+
+    group('hasBlockInChain only checks one level of nestedBlocks', () {
+      test('should find deeply nested blocks', () {
+        final deeplyNested = BlockInfo(
+          name: 'deep',
+          source: 'test.liquid',
+          isOverride: false,
+          nestedBlocks: {},
+          hasSuperCall: false,
+        );
+
+        final middleBlock = BlockInfo(
+          name: 'middle',
+          source: 'test.liquid',
+          isOverride: false,
+          nestedBlocks: {'deep': deeplyNested},
+          hasSuperCall: false,
+        );
+
+        final topBlock = BlockInfo(
+          name: 'top',
+          source: 'test.liquid',
+          isOverride: false,
+          nestedBlocks: {'middle': middleBlock},
+          hasSuperCall: false,
+        );
+
+        final structure = TemplateStructure(
+          templatePath: 'test.liquid',
+          nodes: [],
+          blocks: {'top': topBlock},
+        );
+
+        // Direct nested block should be found
+        expect(structure.hasBlockInChain('middle'), isTrue);
+
+        // Deeply nested block is NOT found (current limitation)
+        expect(
+          structure.hasBlockInChain('deep'),
+          isFalse,
+          reason: 'hasBlockInChain only checks one level of nesting',
+        );
+      });
+    });
+  });
+
+  group('Performance Issues', () {
+    group('resolvedBlocks recomputes every access', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        // Create a 3-level inheritance chain
+        root.addFile('base.liquid', '''
+{% block a %}A{% endblock %}
+{% block b %}B{% endblock %}
+{% block c %}C{% endblock %}
+''');
+        root.addFile('middle.liquid', '''
+{% layout 'base.liquid' %}
+{% block a %}A-middle{% endblock %}
+''');
+        root.addFile('child.liquid', '''
+{% layout 'middle.liquid' %}
+{% block b %}B-child{% endblock %}
+''');
+      });
+
+      test('multiple accesses to resolvedBlocks should be efficient', () {
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final structure = analysis.structures['child.liquid']!;
+
+        // Time multiple accesses
+        final stopwatch = Stopwatch()..start();
+        for (int i = 0; i < 1000; i++) {
+          final _ = structure.resolvedBlocks;
+        }
+        stopwatch.stop();
+
+        // This test documents that each access rebuilds the entire chain
+        // After optimization, repeated access should be near-instant (cached)
+        // Current behavior: each access is O(d * b) where d=depth, b=blocks
+        print(
+          '1000 resolvedBlocks accesses took: ${stopwatch.elapsedMicroseconds} μs',
+        );
+
+        // The result should at least be correct
+        expect(structure.resolvedBlocks.keys.toSet(), equals({'a', 'b', 'c'}));
+      });
+    });
+
+    group('inheritanceChain creates new list every call', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        root.addFile('level1.liquid', '{% block a %}1{% endblock %}');
+        root.addFile(
+          'level2.liquid',
+          "{% layout 'level1.liquid' %}{% block a %}2{% endblock %}",
+        );
+        root.addFile(
+          'level3.liquid',
+          "{% layout 'level2.liquid' %}{% block a %}3{% endblock %}",
+        );
+        root.addFile(
+          'level4.liquid',
+          "{% layout 'level3.liquid' %}{% block a %}4{% endblock %}",
+        );
+        root.addFile(
+          'level5.liquid',
+          "{% layout 'level4.liquid' %}{% block a %}5{% endblock %}",
+        );
+      });
+
+      test('inheritanceChain returns new list instance each time', () {
+        final analysis = analyzer.analyzeTemplate('level5.liquid').last;
+        final structure = analysis.structures['level5.liquid']!;
+
+        final chain1 = structure.inheritanceChain;
+        final chain2 = structure.inheritanceChain;
+
+        // Currently creates new list each time
+        expect(
+          identical(chain1, chain2),
+          isFalse,
+          reason: 'inheritanceChain creates new list on each access',
+        );
+
+        // Content should be the same
+        expect(chain1.length, equals(chain2.length));
+        expect(chain1.length, equals(5));
+      });
+    });
+
+    group('No memoization of template analysis', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        // Diamond inheritance pattern (shared ancestor)
+        //       base
+        //      /    \
+        //   left    right
+        //      \    /
+        //       child
+        root.addFile('base.liquid', '{% block content %}Base{% endblock %}');
+        root.addFile(
+          'left.liquid',
+          "{% layout 'base.liquid' %}{% block content %}Left{% endblock %}",
+        );
+        root.addFile(
+          'right.liquid',
+          "{% layout 'base.liquid' %}{% block content %}Right{% endblock %}",
+        );
+      });
+
+      test('shared ancestor should ideally be analyzed only once', () {
+        // Analyze both paths - base.liquid is a shared ancestor
+        final leftAnalysis = analyzer.analyzeTemplate('left.liquid').last;
+        final rightAnalysis = analyzer.analyzeTemplate('right.liquid').last;
+
+        // Both should have base.liquid in their structures
+        // Currently, base.liquid gets re-analyzed for each path
+        expect(leftAnalysis.structures.containsKey('base.liquid'), isTrue);
+        expect(rightAnalysis.structures.containsKey('base.liquid'), isTrue);
+
+        // This test documents that there's no caching - each analysis
+        // re-parses and re-analyzes the shared ancestor
+        // With memoization, the second analysis should reuse the first
+      });
+    });
+
+    group('O(n) linear search for block lookups in resolver', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        // Create a template with many blocks to stress the linear search
+        final blockDefs = List.generate(
+          50,
+          (i) => '{% block block$i %}Content $i{% endblock %}',
+        ).join('\n');
+
+        root.addFile('base.liquid', blockDefs);
+
+        // Child overrides a few blocks
+        root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block block49 %}Override 49{% endblock %}
+{% block block25 %}Override 25{% endblock %}
+{% block block0 %}Override 0{% endblock %}
+''');
+      });
+
+      test('block resolution with many blocks', () {
+        final stopwatch = Stopwatch()..start();
+
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final structure = analysis.structures['child.liquid']!;
+        final mergedAst = buildCompleteMergedAst(structure);
+
+        stopwatch.stop();
+        print(
+          'Resolution with 50 blocks took: ${stopwatch.elapsedMicroseconds} μs',
+        );
+
+        // Verify correctness
+        final output = _astToString(mergedAst);
+        expect(output, contains('Override 49'));
+        expect(output, contains('Override 25'));
+        expect(output, contains('Override 0'));
+        expect(output, contains('Content 10')); // Non-overridden block
+      });
+    });
+  });
+
+  group('Memory Issues', () {
+    group('Circular references in BlockInfo', () {
+      test('parent-child relationship creates reference cycle', () {
+        final parent = BlockInfo(
+          name: 'parent',
+          source: 'test.liquid',
+          isOverride: false,
+          nestedBlocks: {},
+          hasSuperCall: false,
+        );
+
+        final child = BlockInfo(
+          name: 'child',
+          source: 'test.liquid',
+          isOverride: false,
+          parent: parent, // Points to parent
+          nestedBlocks: {},
+          hasSuperCall: false,
+        );
+
+        // Add child to parent's nestedBlocks
+        // This would create a cycle: parent -> nestedBlocks -> child -> parent
+        // Note: The current API doesn't make this easy, but it's possible
+
+        // For now, just document that parent references exist
+        expect(child.parent, same(parent));
+
+        // This test documents the potential for cycles
+        // GC in Dart can handle cycles, but they may delay collection
+      });
+    });
+
+    group('TemplateStructure parent chain', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        root.addFile('base.liquid', '{% block a %}Base{% endblock %}');
+        root.addFile(
+          'child.liquid',
+          "{% layout 'base.liquid' %}{% block a %}Child{% endblock %}",
+        );
+      });
+
+      test('parent references form a chain that is retained', () {
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final childStructure = analysis.structures['child.liquid']!;
+
+        // Child holds reference to parent
+        expect(childStructure.parent, isNotNull);
+        expect(childStructure.parent!.templatePath, equals('base.liquid'));
+
+        // This chain is retained as long as childStructure is retained
+        // Not necessarily a bug, but worth noting for memory considerations
+      });
+    });
+  });
+
+  group('Dead Code Verification', () {
+    // These tests verify that certain code paths are never reached
+    // They help identify code that can be safely removed
+
+    test('_applyOverride function exists but is not called', () {
+      // The function _applyOverride in resolver.dart (lines 318-382)
+      // duplicates _processNodesWithOverrides but is never called
+      // This test just documents its existence
+
+      // We can't directly test that it's not called, but we can verify
+      // that buildCompleteMergedAst works without it
+      final root = TestRoot();
+      final analyzer = TemplateAnalyzer(root);
+
+      root.addFile('base.liquid', '{% block a %}Base{% endblock %}');
+      root.addFile(
+        'child.liquid',
+        "{% layout 'base.liquid' %}{% block a %}Child{% endblock %}",
+      );
+
+      final analysis = analyzer.analyzeTemplate('child.liquid').last;
+      final structure = analysis.structures['child.liquid']!;
+      final mergedAst = buildCompleteMergedAst(structure);
+
+      expect(_astToString(mergedAst), contains('Child'));
+      // This works without _applyOverride - confirming it's dead code
+    });
+
+    test('resolveSuperCalls function exists but is not called', () {
+      // The function resolveSuperCalls in resolver.dart (lines 384-430)
+      // is never called - super calls are handled inline in _processNodesWithOverrides
+
+      final root = TestRoot();
+      final analyzer = TemplateAnalyzer(root);
+
+      root.addFile('base.liquid', '{% block a %}Base content{% endblock %}');
+      root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block a %}{{ super() }} + Child{% endblock %}
+''');
+
+      final analysis = analyzer.analyzeTemplate('child.liquid').last;
+      final structure = analysis.structures['child.liquid']!;
+      final mergedAst = buildCompleteMergedAst(structure);
+
+      // Super calls work without resolveSuperCalls function
+      final output = _astToString(mergedAst);
+      expect(output, contains('Child'));
+      // Note: The super() content may or may not appear depending on the bug
+    });
+  });
+}
+
+/// Helper function to convert AST nodes to a string for easier validation
+String _astToString(List<ASTNode> nodes) {
+  final buffer = StringBuffer();
+  for (final node in nodes) {
+    _nodeToString(node, buffer);
+  }
+  return buffer.toString();
+}
+
+void _nodeToString(ASTNode node, StringBuffer buffer) {
+  if (node is TextNode) {
+    buffer.write(node.text);
+  } else if (node is Tag) {
+    // For tags, process their body
+    for (final child in node.body) {
+      _nodeToString(child, buffer);
+    }
+  } else if (node is Variable) {
+    buffer.write('{{${node.expression}}}');
+  }
+}

--- a/pkgs/liquify/test/layout/analyzer/layout_analyzer_issues_test.dart
+++ b/pkgs/liquify/test/layout/analyzer/layout_analyzer_issues_test.dart
@@ -8,6 +8,8 @@
 /// Test categories:
 /// - Critical Issues: Bugs that cause incorrect behavior
 /// - Performance Issues: Inefficiencies that affect speed
+library;
+
 /// - Logic Issues: Edge cases not properly handled
 /// - Memory Issues: Resource leaks or circular references
 

--- a/pkgs/liquify/test/layout/analyzer/layout_performance_benchmark_test.dart
+++ b/pkgs/liquify/test/layout/analyzer/layout_performance_benchmark_test.dart
@@ -1,0 +1,464 @@
+import 'package:liquify/src/analyzer/resolver.dart';
+import 'package:liquify/src/analyzer/template_analyzer.dart';
+import 'package:test/test.dart';
+
+import '../../shared_test_root.dart';
+
+/// Comprehensive layout analyzer performance benchmarks.
+/// These tests measure performance across various layout scenarios.
+void main() {
+  group('Layout Performance Benchmarks', () {
+    group('Deep Inheritance Chain', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        // 10-level deep inheritance chain
+        root.addFile('level0.liquid', '''
+{% block header %}Level 0 Header{% endblock %}
+{% block content %}Level 0 Content{% endblock %}
+{% block footer %}Level 0 Footer{% endblock %}
+''');
+
+        for (int i = 1; i < 10; i++) {
+          root.addFile('level$i.liquid', '''
+{% layout 'level${i - 1}.liquid' %}
+{% block content %}Level $i Content - {{ super() }}{% endblock %}
+''');
+        }
+      });
+
+      test('analyze 10-level inheritance', () {
+        final stopwatch = Stopwatch()..start();
+
+        final analysis = analyzer.analyzeTemplate('level9.liquid').last;
+        final structure = analysis.structures['level9.liquid']!;
+
+        stopwatch.stop();
+        final analysisTime = stopwatch.elapsedMicroseconds;
+
+        stopwatch.reset();
+        stopwatch.start();
+        final mergedAst = buildCompleteMergedAst(structure);
+        stopwatch.stop();
+        final mergeTime = stopwatch.elapsedMicroseconds;
+
+        print('=== Deep Inheritance (10 levels) ===');
+        print('Analysis time: $analysisTime μs');
+        print('Merge time: $mergeTime μs');
+        print('Total: ${analysisTime + mergeTime} μs');
+
+        // Verify correctness
+        final output = _astToString(mergedAst);
+        expect(output, contains('Level 0 Header'));
+        expect(output, contains('Level 9 Content'));
+        expect(output, contains('Level 0 Footer'));
+      });
+
+      test('cached 10-level inheritance (second analysis)', () {
+        // First analysis - populates cache
+        analyzer.analyzeTemplate('level9.liquid').last;
+
+        // Second analysis - should use cache
+        final stopwatch = Stopwatch()..start();
+        final analysis = analyzer.analyzeTemplate('level9.liquid').last;
+        final structure = analysis.structures['level9.liquid']!;
+        stopwatch.stop();
+        final analysisTime = stopwatch.elapsedMicroseconds;
+
+        stopwatch.reset();
+        stopwatch.start();
+        final mergedAst = buildCompleteMergedAst(structure);
+        stopwatch.stop();
+        final mergeTime = stopwatch.elapsedMicroseconds;
+
+        print('=== Deep Inheritance CACHED (10 levels) ===');
+        print('Analysis time: $analysisTime μs');
+        print('Merge time: $mergeTime μs');
+        print('Total: ${analysisTime + mergeTime} μs');
+
+        // Verify correctness
+        final output = _astToString(mergedAst);
+        expect(output, contains('Level 0 Header'));
+        expect(output, contains('Level 9 Content'));
+      });
+
+      test('repeated resolvedBlocks access (cached)', () {
+        final analysis = analyzer.analyzeTemplate('level9.liquid').last;
+        final structure = analysis.structures['level9.liquid']!;
+
+        // Warm up cache
+        structure.resolvedBlocks;
+
+        final stopwatch = Stopwatch()..start();
+        for (int i = 0; i < 10000; i++) {
+          final _ = structure.resolvedBlocks;
+        }
+        stopwatch.stop();
+
+        print('=== Cached resolvedBlocks (10k accesses) ===');
+        print('Time: ${stopwatch.elapsedMicroseconds} μs');
+        print('Per access: ${stopwatch.elapsedMicroseconds / 10000} μs');
+      });
+    });
+
+    group('Many Blocks', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        // Base with 100 blocks
+        final blockDefs = List.generate(
+          100,
+          (i) => '{% block block$i %}Content $i{% endblock %}',
+        ).join('\n');
+
+        root.addFile('base.liquid', blockDefs);
+
+        // Child overrides 20 blocks
+        final overrides = List.generate(
+          20,
+          (i) => '{% block block${i * 5} %}Override ${i * 5}{% endblock %}',
+        ).join('\n');
+
+        root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+$overrides
+''');
+      });
+
+      test('resolve 100 blocks with 20 overrides', () {
+        final stopwatch = Stopwatch()..start();
+
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final structure = analysis.structures['child.liquid']!;
+
+        stopwatch.stop();
+        final analysisTime = stopwatch.elapsedMicroseconds;
+
+        stopwatch.reset();
+        stopwatch.start();
+        final mergedAst = buildCompleteMergedAst(structure);
+        stopwatch.stop();
+        final mergeTime = stopwatch.elapsedMicroseconds;
+
+        print('=== Many Blocks (100 blocks, 20 overrides) ===');
+        print('Analysis time: $analysisTime μs');
+        print('Merge time: $mergeTime μs');
+        print('Total: ${analysisTime + mergeTime} μs');
+
+        // Verify correctness
+        final output = _astToString(mergedAst);
+        expect(output, contains('Override 0'));
+        expect(output, contains('Override 95'));
+        expect(output, contains('Content 1')); // Non-overridden
+      });
+    });
+
+    group('Nested Blocks', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        // Template with deeply nested blocks
+        root.addFile('base.liquid', '''
+{% block outer %}
+  Outer Start
+  {% block middle %}
+    Middle Start
+    {% block inner %}
+      Inner Content
+    {% endblock %}
+    Middle End
+  {% endblock %}
+  Outer End
+{% endblock %}
+{% block sidebar %}
+  {% block sidebar_header %}Sidebar Header{% endblock %}
+  {% block sidebar_content %}Sidebar Content{% endblock %}
+  {% block sidebar_footer %}Sidebar Footer{% endblock %}
+{% endblock %}
+''');
+
+        root.addFile('child.liquid', '''
+{% layout 'base.liquid' %}
+{% block inner %}Overridden Inner{% endblock %}
+{% block sidebar_content %}Overridden Sidebar Content{% endblock %}
+''');
+      });
+
+      test('resolve nested block overrides', () {
+        final stopwatch = Stopwatch()..start();
+
+        final analysis = analyzer.analyzeTemplate('child.liquid').last;
+        final structure = analysis.structures['child.liquid']!;
+
+        stopwatch.stop();
+        final analysisTime = stopwatch.elapsedMicroseconds;
+
+        stopwatch.reset();
+        stopwatch.start();
+        final mergedAst = buildCompleteMergedAst(structure);
+        stopwatch.stop();
+        final mergeTime = stopwatch.elapsedMicroseconds;
+
+        print('=== Nested Blocks ===');
+        print('Analysis time: $analysisTime μs');
+        print('Merge time: $mergeTime μs');
+        print('Total: ${analysisTime + mergeTime} μs');
+
+        final output = _astToString(mergedAst);
+        expect(output, contains('Outer Start'));
+        // Note: nested block overrides require the block to be in parent's nested structure
+        expect(output, contains('Overridden Sidebar Content'));
+      });
+    });
+
+    group('Complex Real-World Layout', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        // Simulate a real website structure
+        root.addFile('layouts/base.liquid', '''
+<!DOCTYPE html>
+<html>
+<head>
+  {% block head %}
+    <title>{% block title %}Default Title{% endblock %}</title>
+    {% block meta %}
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% endblock %}
+    {% block styles %}
+      <link rel="stylesheet" href="/css/main.css">
+    {% endblock %}
+  {% endblock %}
+</head>
+<body>
+  {% block body %}
+    <header>
+      {% block header %}
+        {% block nav %}
+          <nav>
+            {% block nav_items %}
+              <a href="/">Home</a>
+              <a href="/about">About</a>
+            {% endblock %}
+          </nav>
+        {% endblock %}
+      {% endblock %}
+    </header>
+    <main>
+      {% block main %}
+        {% block content %}Default Content{% endblock %}
+      {% endblock %}
+    </main>
+    <footer>
+      {% block footer %}
+        {% block footer_content %}
+          <p>Copyright 2024</p>
+        {% endblock %}
+      {% endblock %}
+    </footer>
+  {% endblock %}
+  {% block scripts %}
+    <script src="/js/main.js"></script>
+  {% endblock %}
+</body>
+</html>
+''');
+
+        root.addFile('layouts/page.liquid', '''
+{% layout 'layouts/base.liquid' %}
+{% block styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="/css/page.css">
+{% endblock %}
+{% block nav_items %}
+  {{ super() }}
+  <a href="/contact">Contact</a>
+{% endblock %}
+''');
+
+        root.addFile('layouts/blog.liquid', '''
+{% layout 'layouts/page.liquid' %}
+{% block styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="/css/blog.css">
+{% endblock %}
+{% block main %}
+  <article>
+    {% block article_header %}
+      <h1>{% block article_title %}Blog Post{% endblock %}</h1>
+    {% endblock %}
+    {% block article_content %}
+      {{ super() }}
+    {% endblock %}
+  </article>
+  <aside>
+    {% block sidebar %}
+      <h3>Related Posts</h3>
+    {% endblock %}
+  </aside>
+{% endblock %}
+''');
+
+        root.addFile('posts/my-post.liquid', '''
+{% layout 'layouts/blog.liquid' %}
+{% block title %}My Amazing Post{% endblock %}
+{% block article_title %}My Amazing Post{% endblock %}
+{% block article_content %}
+  <p>This is my blog post content.</p>
+  <p>It has multiple paragraphs.</p>
+{% endblock %}
+{% block sidebar %}
+  {{ super() }}
+  <ul>
+    <li>Related Post 1</li>
+    <li>Related Post 2</li>
+  </ul>
+{% endblock %}
+''');
+      });
+
+      test('resolve 4-level real-world layout', () {
+        final stopwatch = Stopwatch()..start();
+
+        final analysis = analyzer.analyzeTemplate('posts/my-post.liquid').last;
+        final structure = analysis.structures['posts/my-post.liquid']!;
+
+        stopwatch.stop();
+        final analysisTime = stopwatch.elapsedMicroseconds;
+
+        stopwatch.reset();
+        stopwatch.start();
+        final mergedAst = buildCompleteMergedAst(structure);
+        stopwatch.stop();
+        final mergeTime = stopwatch.elapsedMicroseconds;
+
+        print('=== Real-World Layout (4 levels) ===');
+        print('Analysis time: $analysisTime μs');
+        print('Merge time: $mergeTime μs');
+        print('Total: ${analysisTime + mergeTime} μs');
+        print('Blocks in structure: ${structure.resolvedBlocks.length}');
+
+        final output = _astToString(mergedAst);
+        expect(output, contains('My Amazing Post'));
+        // super() tags may not be fully resolved in string output
+        expect(output, contains('page.css'));
+        expect(output, contains('blog.css'));
+        expect(output, contains('Related Post 1'));
+      });
+
+      test('repeated full resolution (simulates page renders)', () {
+        // Simulate rendering the same template multiple times
+        // First pass - cold cache
+        final coldStopwatch = Stopwatch()..start();
+        final analysis1 = analyzer.analyzeTemplate('posts/my-post.liquid').last;
+        final structure1 = analysis1.structures['posts/my-post.liquid']!;
+        final _ = buildCompleteMergedAst(structure1);
+        coldStopwatch.stop();
+        final coldTime = coldStopwatch.elapsedMicroseconds;
+
+        // Subsequent passes - warm cache
+        final warmStopwatch = Stopwatch()..start();
+        for (int i = 0; i < 99; i++) {
+          final analysis = analyzer
+              .analyzeTemplate('posts/my-post.liquid')
+              .last;
+          final structure = analysis.structures['posts/my-post.liquid']!;
+          final _ = buildCompleteMergedAst(structure);
+        }
+        warmStopwatch.stop();
+
+        print('=== 100 Full Resolutions ===');
+        print('Cold (first): $coldTime μs');
+        print('Warm (99 cached): ${warmStopwatch.elapsedMicroseconds} μs');
+        print(
+          'Warm per resolution: ${warmStopwatch.elapsedMicroseconds / 99} μs',
+        );
+        print(
+          'Total time: ${(coldTime + warmStopwatch.elapsedMicroseconds) / 1000} ms',
+        );
+      });
+    });
+
+    group('Stress Test', () {
+      late TestRoot root;
+      late TemplateAnalyzer analyzer;
+
+      setUp(() {
+        root = TestRoot();
+        analyzer = TemplateAnalyzer(root);
+
+        // 20-level inheritance with many blocks each
+        root.addFile('stress/level0.liquid', '''
+{% block a %}A0{% endblock %}
+{% block b %}B0{% endblock %}
+{% block c %}C0{% endblock %}
+{% block d %}D0{% endblock %}
+{% block e %}E0{% endblock %}
+''');
+
+        for (int i = 1; i < 20; i++) {
+          root.addFile('stress/level$i.liquid', '''
+{% layout 'stress/level${i - 1}.liquid' %}
+{% block a %}A$i - {{ super() }}{% endblock %}
+{% block c %}C$i{% endblock %}
+''');
+        }
+      });
+
+      test('20-level inheritance stress test', () {
+        final stopwatch = Stopwatch()..start();
+
+        final analysis = analyzer.analyzeTemplate('stress/level19.liquid').last;
+        final structure = analysis.structures['stress/level19.liquid']!;
+
+        stopwatch.stop();
+        final analysisTime = stopwatch.elapsedMicroseconds;
+
+        stopwatch.reset();
+        stopwatch.start();
+        final mergedAst = buildCompleteMergedAst(structure);
+        stopwatch.stop();
+        final mergeTime = stopwatch.elapsedMicroseconds;
+
+        print('=== Stress Test (20 levels) ===');
+        print('Analysis time: $analysisTime μs');
+        print('Merge time: $mergeTime μs');
+        print('Total: ${analysisTime + mergeTime} μs');
+        print('Inheritance chain length: ${structure.inheritanceChain.length}');
+
+        final output = _astToString(mergedAst);
+        // Block 'a' should have at least the latest level
+        expect(output, contains('A19'));
+        // Block 'c' should be latest override
+        expect(output, contains('C19'));
+        // Block 'b' should be original
+        expect(output, contains('B0'));
+      });
+    });
+  });
+}
+
+String _astToString(List<dynamic> nodes) {
+  final buffer = StringBuffer();
+  for (var node in nodes) {
+    buffer.write(node.toString());
+  }
+  return buffer.toString();
+}

--- a/pkgs/liquify/test/layout/analyzer/multilevel_layout_test.dart
+++ b/pkgs/liquify/test/layout/analyzer/multilevel_layout_test.dart
@@ -71,10 +71,11 @@ void main() {
       expect(resolvedBlocks['content']!.source, equals('parent.liquid'));
       expect(resolvedBlocks['content']!.isOverride, isTrue);
 
-      // The footer is defined only in the child.
+      // The footer is defined only in the child - it's NOT an override
+      // because it doesn't exist in any parent template
       expect(resolvedBlocks['footer'], isNotNull);
       expect(resolvedBlocks['footer']!.source, equals('child.liquid'));
-      expect(resolvedBlocks['footer']!.isOverride, isTrue);
+      expect(resolvedBlocks['footer']!.isOverride, isFalse);
     });
   });
 }

--- a/pkgs/liquify/test/profiling/PROFILING_RESULTS.md
+++ b/pkgs/liquify/test/profiling/PROFILING_RESULTS.md
@@ -1,0 +1,289 @@
+# Liquify Parser Profiling Results
+
+**Date:** January 18, 2026  
+**PetitParser Version:** ^7.0.0  
+**Profiling Tools Used:** `profile()`, `progress()`, `linter()` from `petitparser/debug.dart`
+
+---
+
+## Executive Summary
+
+Profiling the Liquify Liquid template parser revealed several performance bottlenecks and structural issues. The parser shows non-linear scaling with input size, excessive parser activations, and redundant choice patterns flagged by the linter.
+
+---
+
+## 1. Scaling Analysis
+
+| Template Size | Characters | Parser Activations | Ratio vs Baseline |
+|---------------|------------|-------------------|-------------------|
+| Tiny          | 17         | 2,800             | 1.00x             |
+| Small         | 50         | 19,975            | 7.13x             |
+| Medium        | 134        | 21,062            | 7.52x             |
+| Large         | 822        | 130,961           | 46.77x            |
+| XL            | 1,095      | 203,806           | 72.79x            |
+
+**Observation:** Parser activations grow faster than input size, indicating inefficient backtracking or redundant parsing attempts.
+
+---
+
+## 2. Top Time-Consuming Parsers
+
+### Simple Template: `Hello {{ name }}!` (17 chars)
+
+| Count | Time (μs) | Parser |
+|-------|-----------|--------|
+| 1     | 12,708    | SkipParser<Document> |
+| 1     | 12,138    | LabelParser<Document>[document] |
+| 9     | 10,396    | LabelParser<dynamic>[element] |
+| 9     | 10,349    | ChoiceParser<dynamic> |
+| 9     | 3,578     | LabelParser<ASTNode>[variable] |
+
+### Complex Template: E-commerce (822 chars)
+
+| Count | Time (μs) | Parser |
+|-------|-----------|--------|
+| 1     | 77,888    | SkipParser<Document> |
+| 381   | 70,155    | LabelParser<dynamic>[element] |
+| 381   | 69,978    | ChoiceParser<dynamic> |
+| 4     | 47,445    | LabelParser<List>[ifBranchContent] |
+| 4     | 47,442    | LazyRepeatingParser<dynamic>[0..*] |
+
+### Blog Template (1,095 chars)
+
+| Count | Time (μs) | Parser |
+|-------|-----------|--------|
+| 1     | 114,793   | SkipParser<Document> |
+| 564   | 102,673   | LabelParser<dynamic>[element] |
+| 564   | 102,422   | ChoiceParser<dynamic> |
+| 5     | 86,397    | LabelParser<List>[ifBranchContent] |
+| 564   | 12,348    | LabelParser<Tag>[ifBlock] |
+
+---
+
+## 3. Most Activated Parsers
+
+### Whitespace Parsing (Major Issue)
+
+In the Blog template (1,095 chars), whitespace-related parsers dominate:
+
+| Count | Parser |
+|-------|--------|
+| 5,615 | SingleCharacterParser[whitespace expected] |
+| 1,873 | SingleCharacterParser[whitespace expected] |
+| 1,868 | SingleCharacterParser[whitespace expected] |
+| 1,866 | SingleCharacterParser[whitespace expected] (multiple instances) |
+
+**Problem:** Excessive whitespace trimming via `.trim()` causes thousands of unnecessary character checks.
+
+### Choice Parser Activations
+
+| Count | Parser | Context |
+|-------|--------|---------|
+| 3,120 | ChoiceParser<dynamic> | Many Variables (50) test |
+| 1,267 | ChoiceParser<dynamic> | E-commerce template |
+
+**Problem:** The `element()` choice parser tries many alternatives before finding a match.
+
+### Identifier Parsing
+
+| Count | Time (μs) | Parser |
+|-------|-----------|--------|
+| 650   | 16,917    | LabelParser<Identifier>[identifier] |
+| 650   | 12,997    | WhereParser<String> |
+| 650   | 8,972     | FlattenParser |
+
+**Problem:** Identifier parsing is called excessively due to its position in multiple choice parsers.
+
+---
+
+## 4. Linter Analysis Results
+
+### Full Grammar (via `LiquidGrammar().build()`)
+**Result:** No issues found - the `build()` method properly resolves references.
+
+### Unresolved `expression()` Parser
+**Result:** 78 issues found
+
+#### Issue Type 1: Repeated Choices (66 warnings)
+```
+The choices at index 0 and 1 are identical:
+ 0: ReferenceParser<dynamic>
+ 1: ReferenceParser<dynamic>
+The second choice can never succeed and can therefore be removed.
+```
+
+This pattern repeats for many index combinations (0-1, 0-2, 0-3, ..., 10-11), indicating that the `expression()` parser has many `ref0()` calls that resolve to the same parser, creating redundant choice branches.
+
+#### Issue Type 2: Unnecessary Resolvable Parsers (12 warnings)
+```
+Resolvable parsers are used during construction of recursive grammars. 
+While they typically dispatch to their delegate, they add unnecessary 
+overhead and can be avoided by removing them before parsing using `resolve(parser)`.
+```
+
+### Unresolved `element()` Parser
+**Result:** 65 issues found
+
+Similar pattern of repeated choices and unnecessary resolvable parsers.
+
+---
+
+## 5. Specific Parser Bottlenecks
+
+### `expression()` Parser
+
+The expression parser (`shared.dart:224-237`) uses a long chain of `.or()` calls:
+
+```dart
+Parser expression() {
+  return (ref0(logicalExpression)
+          .or(ref0(comparison))
+          .or(ref0(groupedExpression))
+          .or(ref0(arithmeticExpression))
+          .or(ref0(unaryOperation))
+          .or(ref0(arrayAccess))
+          .or(ref0(memberAccess))
+          .or(ref0(assignment))
+          .or(ref0(namedArgument))
+          .or(ref0(literal))
+          .or(ref0(identifier))
+          .or(ref0(range)))
+      .labeled('expression');
+}
+```
+
+**Issues:**
+1. 12 alternatives tried in order for every expression
+2. Many of these start with similar tokens (e.g., identifier)
+3. Backtracking happens frequently
+
+### `element()` Parser
+
+The element parser (`shared.dart:616-628`) is a large choice:
+
+```dart
+Parser element() => [
+  ref0(ifBlock),
+  ref0(forBlock),
+  ref0(caseBlock),
+  ref0(whenBlock),
+  ref0(elseBlockForCase),
+  ref0(elseBlockForFor),
+  ref0(hashBlockComment),
+  ...TagRegistry.customParsers.map((p) => p.parser()),
+  ref0(tag),
+  ref0(variable),
+  ref0(text),
+].toChoiceParser().labeled('element');
+```
+
+**Issues:**
+1. For every character position, all block parsers are tried first
+2. `text()` is last but most frequently matched
+3. Custom parsers add to the choice list dynamically
+
+### `tagStart()` and Tag Detection
+
+```dart
+Parser tagStart() => (string('{%-').trim() | string('{%')).labeled('tagStart');
+```
+
+**Issues:**
+1. The `.trim()` on `{%-` causes whitespace parsing overhead
+2. Both alternatives are tried frequently
+
+---
+
+## 6. Recommendations
+
+### Priority 1: High Impact
+
+1. **Reorder `element()` choices**
+   - Move `text()` higher (or use negative lookahead)
+   - Group tag parsers after checking for `{%` prefix
+   - Consider a two-stage approach: detect delimiter first, then parse
+
+2. **Optimize `expression()` ordering**
+   - Put `identifier` and `literal` earlier (most common)
+   - Use lookahead to avoid trying complex parsers on simple inputs
+
+3. **Reduce whitespace trimming**
+   - Remove `.trim()` from inner parsers
+   - Trim only at tag/variable boundaries
+   - Consider custom whitespace handling
+
+### Priority 2: Medium Impact
+
+4. **Factor out common prefixes**
+   - Many parsers check for `{%` or `{{` repeatedly
+   - Create a single check that branches to the appropriate parser
+
+5. **Optimize identifier parsing**
+   - Cache or memoize identifier results
+   - Consider a specialized identifier parser
+
+6. **Review `tagStart()` trimming**
+   - The `.trim()` on `{%-` variant may be unnecessary
+   - Whitespace control should be handled separately
+
+### Priority 3: Structural Improvements
+
+7. **Use `resolve()` for production parsing**
+   - The linter suggests this reduces overhead
+   - Already done via `LiquidGrammar().build()`
+
+8. **Consider packrat parsing / memoization**
+   - PetitParser supports memoization for expensive parsers
+   - Could help with repeated expression parsing
+
+9. **Profile with real-world templates**
+   - Create benchmarks using actual production templates
+   - Identify patterns that cause worst-case performance
+
+---
+
+## 7. Test Commands
+
+```bash
+# Run all profiling tests
+cd pkgs/liquify
+dart test test/profiling/parser_profiling_test.dart -r expanded
+
+# Run specific test groups
+dart test test/profiling/parser_profiling_test.dart --name "Simple Templates"
+dart test test/profiling/parser_profiling_test.dart --name "Medium Templates"
+dart test test/profiling/parser_profiling_test.dart --name "Complex Templates"
+dart test test/profiling/parser_profiling_test.dart --name "Individual Parser"
+dart test test/profiling/parser_profiling_test.dart --name "Linter"
+dart test test/profiling/parser_profiling_test.dart --name "Comparative"
+dart test test/profiling/parser_profiling_test.dart --name "Progress"
+```
+
+---
+
+## 8. Baseline Metrics (for future comparison)
+
+| Metric | Value |
+|--------|-------|
+| Hello World parse time | ~12,700 μs |
+| E-commerce template parse time | ~77,900 μs |
+| Blog template parse time | ~114,800 μs |
+| Activations per char (tiny) | 165 |
+| Activations per char (XL) | 186 |
+
+---
+
+## 9. Files Modified/Created
+
+- `test/profiling/parser_profiling_test.dart` - Comprehensive profiling test suite
+- `test/profiling/PROFILING_RESULTS.md` - This document
+
+---
+
+## 10. Next Steps
+
+1. [ ] Address Priority 1 recommendations
+2. [ ] Re-run profiling after each change
+3. [ ] Ensure all existing tests pass
+4. [ ] Update baseline metrics
+5. [ ] Consider adding performance regression tests

--- a/pkgs/liquify/test/profiling/parser_profiling_test.dart
+++ b/pkgs/liquify/test/profiling/parser_profiling_test.dart
@@ -1,0 +1,727 @@
+/// Parser Profiling Tests for Liquify
+///
+/// This file contains profiling tests to identify performance bottlenecks
+/// in the Liquify Liquid template parser using PetitParser's profiling tools.
+///
+/// Run with: dart test test/profiling/parser_profiling_test.dart -r expanded
+///
+/// The profiling output shows:
+/// - Activation count: How many times each parser was invoked
+/// - Total time: Microseconds spent in each parser (including children)
+///
+/// Use this to identify:
+/// - Parsers with excessive activations (potential inefficiencies)
+/// - Parsers consuming disproportionate time (bottlenecks)
+/// - Backtracking patterns that could be optimized
+library;
+
+import 'package:liquify/src/grammar/grammar.dart';
+import 'package:liquify/src/grammar/shared.dart';
+import 'package:liquify/src/registry.dart';
+import 'package:petitparser/debug.dart';
+import 'package:petitparser/reflection.dart';
+import 'package:petitparser/petitparser.dart';
+import 'package:test/test.dart';
+
+// ============================================================================
+// Grammar Wrappers for Sub-Parser Testing
+// ============================================================================
+
+/// Grammar wrapper that builds individual sub-parsers with resolved references.
+/// This is necessary because sub-parsers like expression() use ref0() which
+/// creates unresolved references that only work when built through a GrammarDefinition.
+
+class ExpressionGrammar extends GrammarDefinition {
+  @override
+  Parser start() => ref0(expression).end();
+}
+
+class VariableGrammar extends GrammarDefinition {
+  @override
+  Parser start() => ref0(variable).end();
+}
+
+class FilterGrammar extends GrammarDefinition {
+  @override
+  Parser start() => ref0(filter).end();
+}
+
+class ComparisonGrammar extends GrammarDefinition {
+  @override
+  Parser start() => ref0(comparison).end();
+}
+
+class LogicalExpressionGrammar extends GrammarDefinition {
+  @override
+  Parser start() => ref0(logicalExpression).end();
+}
+
+// ============================================================================
+// Benchmark Templates
+// ============================================================================
+
+/// Simple templates for baseline measurements
+class SimpleTemplates {
+  static const helloWorld = 'Hello {{ name }}!';
+
+  static const simpleVariable = '{{ user }}';
+
+  static const variableWithFilter = '{{ name | upcase }}';
+
+  static const multipleFilters =
+      '{{ name | upcase | append: "!" | prepend: "Hello, " }}';
+
+  static const simpleTag = '{% assign x = 5 %}';
+
+  static const simpleIf = '{% if true %}yes{% endif %}';
+
+  static const memberAccess = '{{ user.profile.name }}';
+
+  static const arrayAccess = '{{ items[0] }}';
+}
+
+/// Medium complexity templates
+class MediumTemplates {
+  static const ifElse = '''
+{% if user.logged_in %}
+  <p>Welcome back, {{ user.name }}!</p>
+{% else %}
+  <p>Please log in.</p>
+{% endif %}
+''';
+
+  static const nestedIf = '''
+{% if user.logged_in %}
+  {% if user.admin %}
+    <p>Admin Panel</p>
+  {% else %}
+    <p>User Dashboard</p>
+  {% endif %}
+{% endif %}
+''';
+
+  static const forLoop = '''
+{% for item in items %}
+  <li>{{ item.name }} - {{ item.price | money }}</li>
+{% endfor %}
+''';
+
+  static const forLoopWithElse = '''
+{% for item in items %}
+  <li>{{ item }}</li>
+{% else %}
+  <p>No items found.</p>
+{% endfor %}
+''';
+
+  static const complexExpression = '''
+{% if user.age >= 18 and user.verified == true or user.admin %}
+  <p>Access granted</p>
+{% endif %}
+''';
+
+  static const multipleAssignments = '''
+{% assign greeting = "Hello" %}
+{% assign name = user.first_name | capitalize %}
+{% assign full_greeting = greeting | append: " " | append: name | append: "!" %}
+{{ full_greeting }}
+''';
+
+  static const caseStatement = '''
+{% case day %}
+  {% when "Monday" %}
+    <p>Start of the week</p>
+  {% when "Friday" %}
+    <p>Almost weekend!</p>
+  {% else %}
+    <p>Regular day</p>
+{% endcase %}
+''';
+}
+
+/// Complex templates for stress testing
+class ComplexTemplates {
+  /// Deeply nested if statements (10 levels)
+  static String get deeplyNestedIf {
+    final buffer = StringBuffer();
+    for (var i = 0; i < 10; i++) {
+      buffer.write('{% if level$i %}');
+    }
+    buffer.write('<p>Deep content</p>');
+    for (var i = 9; i >= 0; i--) {
+      buffer.write('{% endif %}');
+    }
+    return buffer.toString();
+  }
+
+  /// Long filter chain (15 filters)
+  static const longFilterChain = '''
+{{ text | strip | downcase | capitalize | prepend: "Hello " | append: "!" | split: " " | first | upcase | strip_html | escape | truncate: 10 | replace: "a", "b" | remove: "x" | strip_newlines | lstrip }}
+''';
+
+  /// Many variables (50 interpolations)
+  static String get manyVariables {
+    final buffer = StringBuffer();
+    for (var i = 0; i < 50; i++) {
+      buffer.write('{{ var$i }}');
+    }
+    return buffer.toString();
+  }
+
+  /// Complex member access chain
+  static const deepMemberAccess = '''
+{{ site.data.navigation.header.menu.items[0].submenu[1].link.url }}
+''';
+
+  /// Multiple nested loops
+  static const nestedLoops = '''
+{% for category in categories %}
+  <h2>{{ category.name }}</h2>
+  {% for product in category.products %}
+    <div>
+      {{ product.name }} - {{ product.price | money }}
+      {% for tag in product.tags %}
+        <span>{{ tag }}</span>
+      {% endfor %}
+    </div>
+  {% endfor %}
+{% endfor %}
+''';
+
+  /// Complex logical expressions
+  static const complexLogical = '''
+{% if (a == 1 and b == 2) or (c == 3 and d == 4) or not e %}
+  {% if x > 10 and x < 20 or y contains "test" %}
+    <p>Complex condition met</p>
+  {% endif %}
+{% endif %}
+''';
+
+  /// Real-world e-commerce template
+  static const ecommerceTemplate = '''
+{% if product.available %}
+  <div class="product">
+    <h1>{{ product.title | escape }}</h1>
+    <p class="price">{{ product.price | money }}</p>
+    
+    {% if product.compare_at_price > product.price %}
+      <p class="sale">Was: {{ product.compare_at_price | money }}</p>
+    {% endif %}
+    
+    {% for variant in product.variants %}
+      {% if variant.available %}
+        <option value="{{ variant.id }}">
+          {{ variant.title }} - {{ variant.price | money }}
+        </option>
+      {% endif %}
+    {% endfor %}
+    
+    {% if product.tags contains "featured" %}
+      <span class="badge">Featured</span>
+    {% endif %}
+    
+    <div class="description">
+      {{ product.description | strip_html | truncate: 200 }}
+    </div>
+  </div>
+{% else %}
+  <p>This product is currently unavailable.</p>
+{% endif %}
+''';
+
+  /// Blog post template with multiple sections
+  static const blogTemplate = '''
+{% if post.published %}
+  <article>
+    <header>
+      <h1>{{ post.title | escape }}</h1>
+      <time>{{ post.date | date: "%B %d, %Y" }}</time>
+      {% if post.author %}
+        <span class="author">by {{ post.author.name }}</span>
+      {% endif %}
+    </header>
+    
+    {% if post.featured_image %}
+      <img src="{{ post.featured_image | img_url: 'large' }}" alt="{{ post.title | escape }}">
+    {% endif %}
+    
+    <div class="content">
+      {{ post.content }}
+    </div>
+    
+    {% if post.tags.size > 0 %}
+      <div class="tags">
+        {% for tag in post.tags %}
+          <a href="/tags/{{ tag | handleize }}">{{ tag }}</a>
+        {% endfor %}
+      </div>
+    {% endif %}
+    
+    {% if post.comments_enabled %}
+      <section class="comments">
+        {% for comment in post.comments %}
+          <div class="comment">
+            <strong>{{ comment.author }}</strong>
+            <time>{{ comment.date | date: "%Y-%m-%d" }}</time>
+            <p>{{ comment.body | escape }}</p>
+          </div>
+        {% endfor %}
+      </section>
+    {% endif %}
+  </article>
+{% endif %}
+''';
+}
+
+// ============================================================================
+// Profiling Utilities
+// ============================================================================
+
+/// Collected profile data for analysis
+class ProfileData {
+  final String parserName;
+  final int activationCount;
+  final int totalMicroseconds;
+
+  ProfileData(this.parserName, this.activationCount, this.totalMicroseconds);
+
+  @override
+  String toString() =>
+      '${activationCount.toString().padLeft(8)}  ${totalMicroseconds.toString().padLeft(10)}  $parserName';
+}
+
+/// Runs profiling on a parser and collects results
+List<ProfileData> runProfile(Parser parser, String input) {
+  final frames = <ProfileData>[];
+
+  final profiledParser = profile(
+    parser,
+    output: (frame) {
+      frames.add(
+        ProfileData(
+          frame.parser.toString(),
+          frame.count,
+          frame.elapsed.inMicroseconds,
+        ),
+      );
+    },
+  );
+
+  profiledParser.parse(input);
+  return frames;
+}
+
+/// Prints a formatted profiling report
+void printProfilingReport(
+  String name,
+  String input,
+  List<ProfileData> frames, {
+  int topN = 15,
+}) {
+  print('\n${'=' * 70}');
+  print('PROFILING: $name');
+  print('${'=' * 70}');
+  print('Input length: ${input.length} characters');
+  print('Total parsers profiled: ${frames.length}');
+
+  // Calculate totals
+  final totalActivations = frames.fold<int>(
+    0,
+    (sum, f) => sum + f.activationCount,
+  );
+  final maxTime = frames.isEmpty
+      ? 0
+      : frames.map((f) => f.totalMicroseconds).reduce((a, b) => a > b ? a : b);
+
+  print('Total activations: $totalActivations');
+  print('Max parser time: $maxTime μs');
+  print('');
+
+  // Sort by time (descending) and show top N
+  final byTime = List<ProfileData>.from(frames)
+    ..sort((a, b) => b.totalMicroseconds.compareTo(a.totalMicroseconds));
+
+  print('TOP $topN BY TIME (μs):');
+  print('${'─' * 70}');
+  print('${' ' * 2}Count${' ' * 5}Time(μs)  Parser');
+  print('${'─' * 70}');
+  for (var i = 0; i < topN && i < byTime.length; i++) {
+    print(byTime[i]);
+  }
+
+  // Sort by activation count (descending) and show top N
+  final byCount = List<ProfileData>.from(frames)
+    ..sort((a, b) => b.activationCount.compareTo(a.activationCount));
+
+  print('');
+  print('TOP $topN BY ACTIVATION COUNT:');
+  print('${'─' * 70}');
+  print('${' ' * 2}Count${' ' * 5}Time(μs)  Parser');
+  print('${'─' * 70}');
+  for (var i = 0; i < topN && i < byCount.length; i++) {
+    print(byCount[i]);
+  }
+
+  print('${'=' * 70}\n');
+}
+
+/// Runs progress tracking on a parser (shows backtracking)
+void runProgress(Parser parser, String input, {int maxLines = 50}) {
+  print('\n--- Progress (first $maxLines lines) ---');
+  print('Input: "$input"');
+  print('');
+  var lineCount = 0;
+  var lastPosition = -1;
+
+  final progressParser = progress(
+    parser,
+    output: (frame) {
+      if (lineCount < maxLines) {
+        // Track position changes to identify backtracking
+        final backtrackIndicator = frame.position < lastPosition
+            ? ' <-- BACKTRACK'
+            : '';
+        print(
+          'pos ${frame.position.toString().padLeft(4)}: ${frame.parser}$backtrackIndicator',
+        );
+        lastPosition = frame.position;
+        lineCount++;
+      }
+    },
+  );
+
+  progressParser.parse(input);
+
+  if (lineCount >= maxLines) {
+    print('... (output truncated)');
+  }
+}
+
+/// Runs the linter on a parser and reports issues
+void runLinter(Parser parser) {
+  print('\n--- Linter Results ---');
+  final issues = linter(parser);
+  if (issues.isEmpty) {
+    print('No issues found.');
+  } else {
+    print('Found ${issues.length} issue(s):');
+    for (final issue in issues) {
+      print('  - $issue');
+    }
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+void main() {
+  // Ensure built-ins are registered
+  registerBuiltIns();
+
+  group('Parser Profiling', () {
+    late Parser documentParser;
+
+    setUp(() {
+      registerBuiltIns();
+      documentParser = LiquidGrammar().build();
+    });
+
+    group('Simple Templates', () {
+      test('Hello World', () {
+        final input = SimpleTemplates.helloWorld;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Hello World', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Simple Variable', () {
+        final input = SimpleTemplates.simpleVariable;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Simple Variable', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Variable with Filter', () {
+        final input = SimpleTemplates.variableWithFilter;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Variable with Filter', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Multiple Filters', () {
+        final input = SimpleTemplates.multipleFilters;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Multiple Filters', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Member Access', () {
+        final input = SimpleTemplates.memberAccess;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Member Access', input, frames);
+        expect(frames, isNotEmpty);
+      });
+    });
+
+    group('Medium Templates', () {
+      test('If-Else Block', () {
+        final input = MediumTemplates.ifElse;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('If-Else Block', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Nested If', () {
+        final input = MediumTemplates.nestedIf;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Nested If', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('For Loop', () {
+        final input = MediumTemplates.forLoop;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('For Loop', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Complex Expression', () {
+        final input = MediumTemplates.complexExpression;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Complex Expression', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Case Statement', () {
+        final input = MediumTemplates.caseStatement;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Case Statement', input, frames);
+        expect(frames, isNotEmpty);
+      });
+    });
+
+    group('Complex Templates (Stress Tests)', () {
+      test('Deeply Nested If (10 levels)', () {
+        final input = ComplexTemplates.deeplyNestedIf;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Deeply Nested If (10 levels)', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Long Filter Chain (15 filters)', () {
+        final input = ComplexTemplates.longFilterChain;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Long Filter Chain', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Many Variables (50)', () {
+        final input = ComplexTemplates.manyVariables;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Many Variables (50)', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Deep Member Access', () {
+        final input = ComplexTemplates.deepMemberAccess;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Deep Member Access', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Nested Loops', () {
+        final input = ComplexTemplates.nestedLoops;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Nested Loops', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Complex Logical Expressions', () {
+        final input = ComplexTemplates.complexLogical;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Complex Logical', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('E-commerce Template', () {
+        final input = ComplexTemplates.ecommerceTemplate;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('E-commerce Template', input, frames);
+        expect(frames, isNotEmpty);
+      });
+
+      test('Blog Template', () {
+        final input = ComplexTemplates.blogTemplate;
+        final frames = runProfile(documentParser, input);
+        printProfilingReport('Blog Template', input, frames);
+        expect(frames, isNotEmpty);
+      });
+    });
+
+    group('Individual Parser Profiling', () {
+      test('expression() parser', () {
+        final parser = ExpressionGrammar().build();
+        final inputs = [
+          'user',
+          'user.name',
+          'user.profile.name',
+          '1 + 2',
+          'a == b',
+          'true and false',
+          'a == 1 and b == 2 or c == 3',
+          'not user.active',
+        ];
+
+        for (final input in inputs) {
+          final frames = runProfile(parser, input);
+          printProfilingReport(
+            'expression(): "$input"',
+            input,
+            frames,
+            topN: 10,
+          );
+        }
+      });
+
+      test('variable() parser', () {
+        final parser = VariableGrammar().build();
+        final inputs = [
+          '{{ x }}',
+          '{{ user.name }}',
+          '{{ price | money }}',
+          '{{ name | upcase | append: "!" }}',
+        ];
+
+        for (final input in inputs) {
+          final frames = runProfile(parser, input);
+          printProfilingReport('variable(): "$input"', input, frames, topN: 10);
+        }
+      });
+
+      test('filter() parser', () {
+        final parser = FilterGrammar().build();
+        final inputs = ['| upcase', '| append: "test"', '| replace: "a", "b"'];
+
+        for (final input in inputs) {
+          final frames = runProfile(parser, input);
+          printProfilingReport('filter(): "$input"', input, frames, topN: 10);
+        }
+      });
+
+      test('comparison() parser', () {
+        final parser = ComparisonGrammar().build();
+        final inputs = ['a == b', '1 < 2', 'x >= 10', 'name contains "test"'];
+
+        for (final input in inputs) {
+          final frames = runProfile(parser, input);
+          printProfilingReport(
+            'comparison(): "$input"',
+            input,
+            frames,
+            topN: 10,
+          );
+        }
+      });
+
+      test('logicalExpression() parser', () {
+        final parser = LogicalExpressionGrammar().build();
+        final inputs = [
+          'true and false',
+          'a or b',
+          'a == 1 and b == 2',
+          'x and y or z',
+        ];
+
+        for (final input in inputs) {
+          final frames = runProfile(parser, input);
+          printProfilingReport(
+            'logicalExpression(): "$input"',
+            input,
+            frames,
+            topN: 10,
+          );
+        }
+      });
+    });
+
+    group('Progress Tracking (Backtracking Analysis)', () {
+      test('Simple variable progress', () {
+        print('\n=== Progress: Simple Variable ===');
+        runProgress(documentParser, '{{ user }}', maxLines: 30);
+      });
+
+      test('If block progress', () {
+        print('\n=== Progress: If Block ===');
+        runProgress(
+          documentParser,
+          '{% if true %}yes{% endif %}',
+          maxLines: 50,
+        );
+      });
+
+      test('Complex expression progress', () {
+        print('\n=== Progress: Complex Expression ===');
+        final input = '{% if a == 1 and b == 2 %}yes{% endif %}';
+        runProgress(documentParser, input, maxLines: 80);
+      });
+    });
+
+    group('Linter Analysis', () {
+      test('Full grammar linter check', () {
+        print('\n=== Linter: Full Grammar ===');
+        runLinter(documentParser);
+      });
+
+      test('expression() linter check', () {
+        print('\n=== Linter: expression() ===');
+        runLinter(expression());
+      });
+
+      test('element() linter check', () {
+        print('\n=== Linter: element() ===');
+        runLinter(element());
+      });
+    });
+
+    group('Comparative Analysis', () {
+      test('Compare activation counts across template sizes', () {
+        final templates = {
+          'Tiny (15 chars)': SimpleTemplates.helloWorld,
+          'Small (50 chars)': MediumTemplates.ifElse.substring(0, 50),
+          'Medium (200 chars)': MediumTemplates.nestedIf,
+          'Large (500+ chars)': ComplexTemplates.ecommerceTemplate,
+          'XL (1000+ chars)': ComplexTemplates.blogTemplate,
+        };
+
+        print('\n${'=' * 70}');
+        print('COMPARATIVE ANALYSIS: Activation Counts by Template Size');
+        print('${'=' * 70}');
+        print(
+          '${'Template'.padRight(25)} ${'Chars'.padLeft(8)} ${'Activations'.padLeft(12)} ${'Ratio'.padLeft(10)}',
+        );
+        print('${'─' * 70}');
+
+        int? baselineActivations;
+
+        for (final entry in templates.entries) {
+          final frames = runProfile(documentParser, entry.value);
+          final totalActivations = frames.fold<int>(
+            0,
+            (sum, f) => sum + f.activationCount,
+          );
+
+          baselineActivations ??= totalActivations;
+          final ratio = (totalActivations / baselineActivations)
+              .toStringAsFixed(2);
+
+          print(
+            '${entry.key.padRight(25)} ${entry.value.length.toString().padLeft(8)} ${totalActivations.toString().padLeft(12)} ${ratio.padLeft(10)}x',
+          );
+        }
+
+        print('${'=' * 70}\n');
+      });
+    });
+  });
+}

--- a/pkgs/liquify/test/profiling/parser_profiling_test.dart
+++ b/pkgs/liquify/test/profiling/parser_profiling_test.dart
@@ -767,14 +767,14 @@ void main() {
 
         print('Simple variable activations: $totalActivations');
 
-        // Baseline after expression parser optimization: ~310
+        // Baseline after text() optimization: ~299
         // Allow 20% tolerance for minor variations
         expect(
           totalActivations,
-          lessThan(400),
+          lessThan(360),
           reason:
               'Simple variable parsing regressed. '
-              'Expected <400, got $totalActivations',
+              'Expected <360, got $totalActivations',
         );
       });
 
@@ -824,13 +824,13 @@ void main() {
 
         print('For loop activations: $totalActivations');
 
-        // Baseline: ~2500-3000
+        // Baseline after text() optimization: ~1686
         expect(
           totalActivations,
-          lessThan(4000),
+          lessThan(2100),
           reason:
               'For loop parsing regressed. '
-              'Expected <4000, got $totalActivations',
+              'Expected <2100, got $totalActivations',
         );
       });
 

--- a/pkgs/liquify/test/profiling/parser_profiling_test.dart
+++ b/pkgs/liquify/test/profiling/parser_profiling_test.dart
@@ -768,7 +768,8 @@ void main() {
         print('Simple variable activations: $totalActivations');
 
         // Baseline after text() optimization: ~299
-        // Allow 20% tolerance for minor variations
+        // After primaryTerm() optimization: ~274
+        // Allow 30% tolerance for minor variations
         expect(
           totalActivations,
           lessThan(360),

--- a/pkgs/liquify/test/profiling/parser_profiling_test.dart
+++ b/pkgs/liquify/test/profiling/parser_profiling_test.dart
@@ -20,7 +20,6 @@ import 'package:liquify/src/grammar/shared.dart';
 import 'package:liquify/src/registry.dart';
 import 'package:petitparser/debug.dart';
 import 'package:petitparser/reflection.dart';
-import 'package:petitparser/petitparser.dart';
 import 'package:test/test.dart';
 
 // ============================================================================
@@ -345,7 +344,7 @@ void printProfilingReport(
 }) {
   print('\n${'=' * 70}');
   print('PROFILING: $name');
-  print('${'=' * 70}');
+  print('=' * 70);
   print('Input length: ${input.length} characters');
   print('Total parsers profiled: ${frames.length}');
 
@@ -367,9 +366,9 @@ void printProfilingReport(
     ..sort((a, b) => b.totalMicroseconds.compareTo(a.totalMicroseconds));
 
   print('TOP $topN BY TIME (μs):');
-  print('${'─' * 70}');
+  print('─' * 70);
   print('${' ' * 2}Count${' ' * 5}Time(μs)  Parser');
-  print('${'─' * 70}');
+  print('─' * 70);
   for (var i = 0; i < topN && i < byTime.length; i++) {
     print(byTime[i]);
   }
@@ -380,9 +379,9 @@ void printProfilingReport(
 
   print('');
   print('TOP $topN BY ACTIVATION COUNT:');
-  print('${'─' * 70}');
+  print('─' * 70);
   print('${' ' * 2}Count${' ' * 5}Time(μs)  Parser');
-  print('${'─' * 70}');
+  print('─' * 70);
   for (var i = 0; i < topN && i < byCount.length; i++) {
     print(byCount[i]);
   }
@@ -721,11 +720,11 @@ void main() {
 
         print('\n${'=' * 70}');
         print('COMPARATIVE ANALYSIS: Activation Counts by Template Size');
-        print('${'=' * 70}');
+        print('=' * 70);
         print(
           '${'Template'.padRight(25)} ${'Chars'.padLeft(8)} ${'Activations'.padLeft(12)} ${'Ratio'.padLeft(10)}',
         );
-        print('${'─' * 70}');
+        print('─' * 70);
 
         int? baselineActivations;
 
@@ -896,11 +895,11 @@ void main() {
 
         print('\n${'=' * 70}');
         print('BENCHMARK: identifier() parser');
-        print('${'=' * 70}');
+        print('=' * 70);
         print(
           '${'Input'.padRight(30)} ${'Chars'.padLeft(6)} ${'Activations'.padLeft(12)}',
         );
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (final input in inputs) {
           final frames = runProfile(parser, input);
@@ -936,11 +935,11 @@ void main() {
 
         print('\n${'=' * 70}');
         print('BENCHMARK: primaryTerm() parser');
-        print('${'=' * 70}');
+        print('=' * 70);
         print(
           '${'Type'.padRight(20)} ${'Input'.padRight(15)} ${'Activations'.padLeft(12)}',
         );
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (final entry in inputs.entries) {
           final frames = runProfile(parser, entry.value);
@@ -961,9 +960,9 @@ void main() {
 
         print('\n${'=' * 70}');
         print('BENCHMARK: arithmeticExpr() parser');
-        print('${'=' * 70}');
+        print('=' * 70);
         print('${'Input'.padRight(20)} ${'Activations'.padLeft(12)}');
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (final input in inputs) {
           final frames = runProfile(parser, input);
@@ -988,9 +987,9 @@ void main() {
 
         print('\n${'=' * 70}');
         print('BENCHMARK: comparisonExpr() parser');
-        print('${'=' * 70}');
+        print('=' * 70);
         print('${'Input'.padRight(25)} ${'Activations'.padLeft(12)}');
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (final input in inputs) {
           final frames = runProfile(parser, input);
@@ -1015,9 +1014,9 @@ void main() {
 
         print('\n${'=' * 70}');
         print('BENCHMARK: logicalExpr() parser');
-        print('${'=' * 70}');
+        print('=' * 70);
         print('${'Input'.padRight(25)} ${'Activations'.padLeft(12)}');
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (final input in inputs) {
           final frames = runProfile(parser, input);
@@ -1043,11 +1042,11 @@ void main() {
 
         print('\n${'=' * 70}');
         print('BENCHMARK: expression() precedence chain');
-        print('${'=' * 70}');
+        print('=' * 70);
         print(
           '${'Type'.padRight(20)} ${'Input'.padRight(30)} ${'Activations'.padLeft(12)}',
         );
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (final entry in inputs.entries) {
           final frames = runProfile(parser, entry.value);
@@ -1080,11 +1079,11 @@ void main() {
 
         print('\n${'=' * 70}');
         print('TIMING BENCHMARK: Parse Time by Template Size');
-        print('${'=' * 70}');
+        print('=' * 70);
         print(
           '${'Template'.padRight(12)} ${'Chars'.padLeft(8)} ${'Parse (μs)'.padLeft(12)} ${'μs/char'.padLeft(10)}',
         );
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (final entry in templates.entries) {
           final input = entry.value;
@@ -1138,7 +1137,7 @@ void main() {
 
         print('\n${'=' * 70}');
         print('TIMING VARIANCE: E-commerce Template (${input.length} chars)');
-        print('${'=' * 70}');
+        print('=' * 70);
         print('Samples: ${times.length}');
         print('Min:     $min μs');
         print('Max:     $max μs');
@@ -1184,7 +1183,7 @@ void main() {
 
         print('\n${'=' * 70}');
         print('THROUGHPUT BENCHMARK');
-        print('${'=' * 70}');
+        print('=' * 70);
         print('Template size: ${input.length} characters');
         print('Iterations in 1s: $iterations');
         print(
@@ -1225,9 +1224,9 @@ void main() {
 
         print('\n${'=' * 70}');
         print('HOTSPOT ANALYSIS: E-commerce Template');
-        print('${'=' * 70}');
+        print('=' * 70);
         print('${'Parser'.padRight(50)} ${'Count'.padLeft(10)}');
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (var i = 0; i < 20 && i < sorted.length; i++) {
           final entry = sorted[i];
@@ -1249,11 +1248,11 @@ void main() {
 
         print('\n${'=' * 70}');
         print('WHITESPACE ANALYSIS');
-        print('${'=' * 70}');
+        print('=' * 70);
         print(
           '${'Template'.padRight(25)} ${'Whitespace Activations'.padLeft(25)}',
         );
-        print('${'─' * 70}');
+        print('─' * 70);
 
         for (final entry in templates.entries) {
           final frames = runProfile(documentParser, entry.value);
@@ -1278,9 +1277,9 @@ void main() {
 
         print('\n${'=' * 70}');
         print('CHOICE PARSER ANALYSIS: Complex Expression');
-        print('${'=' * 70}');
+        print('=' * 70);
         print('${'Parser'.padRight(50)} ${'Count'.padLeft(10)}');
-        print('${'─' * 70}');
+        print('─' * 70);
 
         final totalChoiceActivations = choiceParsers.fold<int>(
           0,
@@ -1296,7 +1295,7 @@ void main() {
             '${name.padRight(50)} ${frame.activationCount.toString().padLeft(10)}',
           );
         }
-        print('${'─' * 70}');
+        print('─' * 70);
         print(
           '${'Total ChoiceParser activations:'.padRight(50)} ${totalChoiceActivations.toString().padLeft(10)}',
         );

--- a/pkgs/liquify/test/support/golden_harness.dart
+++ b/pkgs/liquify/test/support/golden_harness.dart
@@ -117,9 +117,11 @@ class _GoldenRecorder {
 
   final Directory _dir;
   final bool _update = Platform.environment['UPDATE_GOLDENS'] == '1';
+  final bool _skip = Platform.environment['SKIP_GOLDENS'] == '1';
 
   Directory get dir => _dir;
   bool get updating => _update;
+  bool get skipping => _skip;
 
   static Directory _resolveGoldenDir() {
     final override = Platform.environment['GOLDEN_DIR'];
@@ -176,6 +178,11 @@ class _GoldenRecorder {
   }
 
   void record(Object? actual, Object? matcher, StackTrace trace) {
+    // Skip golden comparison if SKIP_GOLDENS=1
+    if (_skip) {
+      return;
+    }
+
     final context = Zone.current[_goldenContextKey] as _GoldenContext?;
     if (context == null) {
       return;

--- a/pkgs/liquify/test/tags/custom_tag_delimiter_test.dart
+++ b/pkgs/liquify/test/tags/custom_tag_delimiter_test.dart
@@ -1,8 +1,8 @@
 import 'package:liquify/parser.dart';
 import 'package:liquify/src/buffer.dart';
+import 'package:liquify/src/config.dart';
 import 'package:liquify/src/context.dart';
 import 'package:liquify/src/evaluator.dart';
-import 'package:petitparser/petitparser.dart';
 import 'package:test/test.dart';
 
 /// A custom tag using standard {% %} delimiters (default)
@@ -21,11 +21,12 @@ class HelloTag extends AbstractTag with CustomTagParser {
   // Uses default TagDelimiterType.tag - no override needed
 
   @override
-  Parser parser() {
-    return (tagStart() &
+  Parser parser([LiquidConfig? config]) {
+    // Use createTagStart/createTagEnd to support custom delimiters
+    return (createTagStart(config) &
             string('hello').trim() &
             ref0(expression).optional().trim() &
-            tagEnd())
+            createTagEnd(config))
         .map((values) {
           final expr = values[2];
           return Tag('hello', expr != null ? [expr as ASTNode] : []);
@@ -50,14 +51,15 @@ class GreetTag extends AbstractTag with CustomTagParser {
   TagDelimiterType get delimiterType => TagDelimiterType.variable;
 
   @override
-  Parser parser() {
+  Parser parser([LiquidConfig? config]) {
     // Matches: {{ greet("name") }} or {{ greet(variable) }}
-    return (varStart() &
+    // Use createVarStart/createVarEnd to support custom delimiters
+    return (createVarStart(config) &
             string('greet').trim() &
             char('(').trim() &
             ref0(expression).trim() &
             char(')').trim() &
-            varEnd())
+            createVarEnd(config))
         .map((values) {
           final expr = values[3] as ASTNode;
           return Tag('greet', [expr]);
@@ -79,12 +81,13 @@ class NowTag extends AbstractTag with CustomTagParser {
   TagDelimiterType get delimiterType => TagDelimiterType.variable;
 
   @override
-  Parser parser() {
-    return (varStart() &
+  Parser parser([LiquidConfig? config]) {
+    // Use createVarStart/createVarEnd to support custom delimiters
+    return (createVarStart(config) &
             string('now').trim() &
             char('(').trim() &
             char(')').trim() &
-            varEnd())
+            createVarEnd(config))
         .map((_) {
           return Tag('now', []);
         });

--- a/pkgs/liquify/test/tags/custom_tag_delimiter_test.dart
+++ b/pkgs/liquify/test/tags/custom_tag_delimiter_test.dart
@@ -1,0 +1,296 @@
+import 'package:liquify/parser.dart';
+import 'package:liquify/src/buffer.dart';
+import 'package:liquify/src/context.dart';
+import 'package:liquify/src/evaluator.dart';
+import 'package:petitparser/petitparser.dart';
+import 'package:test/test.dart';
+
+/// A custom tag using standard {% %} delimiters (default)
+/// Usage: {% hello name %}
+class HelloTag extends AbstractTag with CustomTagParser {
+  HelloTag(super.content, super.filters);
+
+  @override
+  dynamic evaluateWithContext(Evaluator evaluator, Buffer buffer) {
+    final name = content.isNotEmpty
+        ? evaluator.evaluate(content.first)
+        : 'World';
+    buffer.write('Hello, $name!');
+  }
+
+  // Uses default TagDelimiterType.tag - no override needed
+
+  @override
+  Parser parser() {
+    return (tagStart() &
+            string('hello').trim() &
+            ref0(expression).optional().trim() &
+            tagEnd())
+        .map((values) {
+          final expr = values[2];
+          return Tag('hello', expr != null ? [expr as ASTNode] : []);
+        });
+  }
+}
+
+/// A custom tag using {{ }} variable-style delimiters
+/// Usage: {{ greet("name") }}
+class GreetTag extends AbstractTag with CustomTagParser {
+  GreetTag(super.content, super.filters);
+
+  @override
+  dynamic evaluateWithContext(Evaluator evaluator, Buffer buffer) {
+    final name = content.isNotEmpty
+        ? evaluator.evaluate(content.first)
+        : 'World';
+    buffer.write('Greetings, $name!');
+  }
+
+  @override
+  TagDelimiterType get delimiterType => TagDelimiterType.variable;
+
+  @override
+  Parser parser() {
+    // Matches: {{ greet("name") }} or {{ greet(variable) }}
+    return (varStart() &
+            string('greet').trim() &
+            char('(').trim() &
+            ref0(expression).trim() &
+            char(')').trim() &
+            varEnd())
+        .map((values) {
+          final expr = values[3] as ASTNode;
+          return Tag('greet', [expr]);
+        });
+  }
+}
+
+/// A custom tag using {{ }} delimiters with no arguments
+/// Usage: {{ now() }}
+class NowTag extends AbstractTag with CustomTagParser {
+  NowTag(super.content, super.filters);
+
+  @override
+  dynamic evaluateWithContext(Evaluator evaluator, Buffer buffer) {
+    buffer.write('NOW');
+  }
+
+  @override
+  TagDelimiterType get delimiterType => TagDelimiterType.variable;
+
+  @override
+  Parser parser() {
+    return (varStart() &
+            string('now').trim() &
+            char('(').trim() &
+            char(')').trim() &
+            varEnd())
+        .map((_) {
+          return Tag('now', []);
+        });
+  }
+}
+
+void main() {
+  late Evaluator evaluator;
+
+  setUpAll(() {
+    // Register our custom tags
+    TagRegistry.register(
+      'hello',
+      (content, filters) => HelloTag(content, filters),
+    );
+    TagRegistry.register(
+      'greet',
+      (content, filters) => GreetTag(content, filters),
+    );
+    TagRegistry.register('now', (content, filters) => NowTag(content, filters));
+  });
+
+  setUp(() {
+    evaluator = Evaluator(Environment());
+  });
+
+  tearDown(() {
+    evaluator.context.clear();
+  });
+
+  group('Custom Tag Delimiter Types', () {
+    group('TagDelimiterType.tag ({% %} syntax)', () {
+      test('parses custom tag with standard delimiters', () {
+        final source = '{% hello "Alice" %}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('Hello, Alice!'));
+      });
+
+      test('parses custom tag with variable argument', () {
+        final source = '{% assign name = "Bob" %}{% hello name %}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('Hello, Bob!'));
+      });
+
+      test('parses custom tag without argument', () {
+        final source = '{% hello %}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('Hello, World!'));
+      });
+
+      test('custom tag with {% %} does NOT parse with {{ }} delimiters', () {
+        // This should be treated as a variable lookup, not our custom tag
+        final source = '{{ hello }}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        // 'hello' is undefined, so it outputs empty
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals(''));
+      });
+    });
+
+    group('TagDelimiterType.variable ({{ }} syntax)', () {
+      test('parses custom tag with variable delimiters', () {
+        final source = '{{ greet("Carol") }}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('Greetings, Carol!'));
+      });
+
+      test('parses custom tag with variable argument', () {
+        final source = '{% assign name = "Dave" %}{{ greet(name) }}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('Greetings, Dave!'));
+      });
+
+      test('parses custom tag with no arguments', () {
+        final source = '{{ now() }}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('NOW'));
+      });
+
+      test('tag still works with {% %} via generic parser', () {
+        // Note: The custom parser's delimiterType only controls which delimiter
+        // triggers the custom parser. The generic tag parser can still parse
+        // {% greet(...) %} and the tag factory will create a GreetTag.
+        // This is by design - delimiterType is about WHICH custom parser runs,
+        // not about restricting the tag to only one delimiter type.
+        final source = '{% greet("Eve") %}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        // The generic tag parser creates a Tag('greet', ...) which the
+        // tag factory turns into a GreetTag
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('Greetings, Eve!'));
+      });
+    });
+
+    group('Mixed delimiter types in same template', () {
+      test('both custom tag types work together', () {
+        final source = '{% hello "Frank" %} and {{ greet("Grace") }}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(
+          evaluator.buffer.toString(),
+          equals('Hello, Frank! and Greetings, Grace!'),
+        );
+      });
+
+      test('custom tags work with standard Liquid tags', () {
+        final source =
+            '{% assign items = "a,b,c" | split: "," %}{% for item in items %}{{ greet(item) }} {% endfor %}{% hello "end" %}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        final output = evaluator.buffer.toString();
+        expect(output, contains('Greetings, a!'));
+        expect(output, contains('Greetings, b!'));
+        expect(output, contains('Greetings, c!'));
+        expect(output, contains('Hello, end!'));
+      });
+
+      test('custom tags work with standard variables', () {
+        final source = '{{ now() }} - {% assign x = 42 %}{{ x }}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('NOW - 42'));
+      });
+    });
+
+    group('Edge cases', () {
+      test('whitespace handling in variable-style custom tag', () {
+        final source = '{{  greet( "spaces" )  }}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('Greetings, spaces!'));
+      });
+
+      test('whitespace handling in tag-style custom tag', () {
+        final source = '{%  hello  "spaces"  %}';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
+
+        evaluator.evaluateNodes(document.children);
+        expect(evaluator.buffer.toString(), equals('Hello, spaces!'));
+      });
+
+      test(
+        '{{- variant parses custom tags (whitespace control not implemented)',
+        () {
+          // Note: Liquid's whitespace stripping feature ({{- and -{}}) is not
+          // currently implemented in this parser. The {{- syntax is recognized
+          // but does not actually strip whitespace from adjacent text.
+          final source = 'before {{- now() }} after';
+          final nodes = parseInput(source);
+          final document = Document(nodes);
+
+          evaluator.evaluateNodes(document.children);
+          // Currently whitespace is NOT stripped - feature not implemented
+          expect(evaluator.buffer.toString(), equals('before NOW after'));
+        },
+      );
+
+      test(
+        '{%- variant parses custom tags (whitespace control not implemented)',
+        () {
+          // Note: Liquid's whitespace stripping feature ({%- and -%}) is not
+          // currently implemented in this parser. The {%- syntax is recognized
+          // but does not actually strip whitespace from adjacent text.
+          final source = 'before {%- hello "test" %} after';
+          final nodes = parseInput(source);
+          final document = Document(nodes);
+
+          evaluator.evaluateNodes(document.children);
+          // Currently whitespace is NOT stripped - feature not implemented
+          expect(
+            evaluator.buffer.toString(),
+            equals('before Hello, test! after'),
+          );
+        },
+      );
+    });
+  });
+}

--- a/pkgs/liquify/test/tags/custom_tag_delimiter_test.dart
+++ b/pkgs/liquify/test/tags/custom_tag_delimiter_test.dart
@@ -1,8 +1,4 @@
 import 'package:liquify/parser.dart';
-import 'package:liquify/src/buffer.dart';
-import 'package:liquify/src/config.dart';
-import 'package:liquify/src/context.dart';
-import 'package:liquify/src/evaluator.dart';
 import 'package:test/test.dart';
 
 /// A custom tag using standard {% %} delimiters (default)

--- a/pkgs/liquify/test/tags/custom_tag_delimiter_test.dart
+++ b/pkgs/liquify/test/tags/custom_tag_delimiter_test.dart
@@ -257,40 +257,27 @@ void main() {
         expect(evaluator.buffer.toString(), equals('Hello, spaces!'));
       });
 
-      test(
-        '{{- variant parses custom tags (whitespace control not implemented)',
-        () {
-          // Note: Liquid's whitespace stripping feature ({{- and -{}}) is not
-          // currently implemented in this parser. The {{- syntax is recognized
-          // but does not actually strip whitespace from adjacent text.
-          final source = 'before {{- now() }} after';
-          final nodes = parseInput(source);
-          final document = Document(nodes);
+      test('{{- variant strips preceding whitespace with custom tags', () {
+        // Liquid's whitespace stripping: {{- strips whitespace before the tag
+        final source = 'before {{- now() }} after';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
 
-          evaluator.evaluateNodes(document.children);
-          // Currently whitespace is NOT stripped - feature not implemented
-          expect(evaluator.buffer.toString(), equals('before NOW after'));
-        },
-      );
+        evaluator.evaluateNodes(document.children);
+        // {{- strips preceding whitespace
+        expect(evaluator.buffer.toString(), equals('beforeNOW after'));
+      });
 
-      test(
-        '{%- variant parses custom tags (whitespace control not implemented)',
-        () {
-          // Note: Liquid's whitespace stripping feature ({%- and -%}) is not
-          // currently implemented in this parser. The {%- syntax is recognized
-          // but does not actually strip whitespace from adjacent text.
-          final source = 'before {%- hello "test" %} after';
-          final nodes = parseInput(source);
-          final document = Document(nodes);
+      test('{%- variant strips preceding whitespace with custom tags', () {
+        // Liquid's whitespace stripping: {%- strips whitespace before the tag
+        final source = 'before {%- hello "test" %} after';
+        final nodes = parseInput(source);
+        final document = Document(nodes);
 
-          evaluator.evaluateNodes(document.children);
-          // Currently whitespace is NOT stripped - feature not implemented
-          expect(
-            evaluator.buffer.toString(),
-            equals('before Hello, test! after'),
-          );
-        },
-      );
+        evaluator.evaluateNodes(document.children);
+        // {%- strips preceding whitespace
+        expect(evaluator.buffer.toString(), equals('beforeHello, test! after'));
+      });
     });
   });
 }

--- a/pkgs/liquify/test/tags/custom_tag_with_custom_delimiters_test.dart
+++ b/pkgs/liquify/test/tags/custom_tag_with_custom_delimiters_test.dart
@@ -1,0 +1,189 @@
+import 'package:liquify/liquify.dart';
+import 'package:liquify/parser.dart';
+import 'package:test/test.dart';
+
+/// Custom tag that uses tag delimiters ({% %} or <% %> etc.)
+class ShoutTag extends AbstractTag with CustomTagParser {
+  ShoutTag(super.content, super.filters);
+
+  @override
+  dynamic evaluateWithContext(Evaluator evaluator, Buffer buffer) {
+    final text = content.isNotEmpty
+        ? evaluator.evaluate(content.first)?.toString() ?? ''
+        : '';
+    buffer.write(text.toUpperCase());
+  }
+
+  @override
+  Parser parser([LiquidConfig? config]) {
+    return (createTagStart(config) &
+            string('shout').trim() &
+            ref0(expression).optional().trim() &
+            createTagEnd(config))
+        .map((values) {
+          final expr = values[2];
+          return Tag('shout', expr != null ? [expr as ASTNode] : []);
+        });
+  }
+}
+
+void main() {
+  group('Custom Tags with Custom Delimiters', () {
+    setUpAll(() {
+      // Register custom tag
+      TagRegistry.register(
+        'shout',
+        (content, filters) => ShoutTag(content, filters),
+      );
+    });
+
+    group('Standard delimiters', () {
+      late Liquid liquid;
+
+      setUp(() {
+        liquid = Liquid();
+      });
+
+      test('tag-style custom tag works', () {
+        final result = liquid.renderString('{% shout "hello" %}', {});
+        expect(result, equals('HELLO'));
+      });
+
+      test('custom tags work with variables', () {
+        final result = liquid.renderString(
+          '{% assign msg = "test" %}{% shout msg %}',
+          {},
+        );
+        expect(result, equals('TEST'));
+      });
+    });
+
+    group('ERB-style delimiters', () {
+      late Liquid liquid;
+
+      setUp(() {
+        liquid = Liquid(config: LiquidConfig.erb);
+      });
+
+      test('tag-style custom tag works with ERB delimiters', () {
+        final result = liquid.renderString('<% shout "hello" %>', {});
+        expect(result, equals('HELLO'));
+      });
+
+      test('custom tags work with variables using ERB delimiters', () {
+        final result = liquid.renderString(
+          '<% assign msg = "test" %><% shout msg %>',
+          {},
+        );
+        expect(result, equals('TEST'));
+      });
+
+      test('custom tags mix with standard Liquid tags (ERB)', () {
+        final result = liquid.renderString(
+          '<% if true %><% shout "yes" %><% endif %>',
+          {},
+        );
+        expect(result, equals('YES'));
+      });
+
+      test('custom tags in for loop (ERB)', () {
+        final result = liquid.renderString(
+          '<% for item in items %><% shout item %> <% endfor %>',
+          {
+            'items': ['a', 'b', 'c'],
+          },
+        );
+        expect(result, contains('A'));
+        expect(result, contains('B'));
+        expect(result, contains('C'));
+      });
+    });
+
+    group('Bracket-style delimiters', () {
+      late Liquid liquid;
+
+      setUp(() {
+        liquid = Liquid(
+          config: const LiquidConfig(
+            tagStart: '[%',
+            tagEnd: '%]',
+            varStart: '[[',
+            varEnd: ']]',
+          ),
+        );
+      });
+
+      test('tag-style custom tag works with bracket delimiters', () {
+        final result = liquid.renderString('[% shout "hello" %]', {});
+        expect(result, equals('HELLO'));
+      });
+
+      test('custom tags work with standard tags using bracket delimiters', () {
+        final result = liquid.renderString(
+          '[% for i in (1..3) %][% shout i %][% endfor %]',
+          {},
+        );
+        expect(result, contains('1'));
+        expect(result, contains('2'));
+        expect(result, contains('3'));
+      });
+    });
+
+    group('Multiple Liquid instances with different delimiters', () {
+      test('custom tags work correctly in each instance', () {
+        final liquidStd = Liquid();
+        final liquidErb = Liquid(config: LiquidConfig.erb);
+        final liquidBracket = Liquid(
+          config: const LiquidConfig(
+            tagStart: '[%',
+            tagEnd: '%]',
+            varStart: '[[',
+            varEnd: ']]',
+          ),
+        );
+
+        // Standard
+        expect(liquidStd.renderString('{% shout "std" %}', {}), equals('STD'));
+
+        // ERB
+        expect(liquidErb.renderString('<% shout "erb" %>', {}), equals('ERB'));
+
+        // Bracket
+        expect(
+          liquidBracket.renderString('[% shout "bracket" %]', {}),
+          equals('BRACKET'),
+        );
+
+        // Verify they don't cross-pollinate
+        expect(
+          liquidErb.renderString('{% shout "should not work" %}', {}),
+          equals('{% shout "should not work" %}'), // Treated as text
+        );
+      });
+    });
+
+    group('Edge cases', () {
+      test('whitespace stripping works with custom tags (ERB)', () {
+        final liquid = Liquid(config: LiquidConfig.erb);
+        final result = liquid.renderString(
+          'before <%- shout "test" %> after',
+          {},
+        );
+        expect(result, equals('beforeTEST after'));
+      });
+
+      test('nested custom tags in control flow', () {
+        final liquid = Liquid(config: LiquidConfig.erb);
+        final result = liquid.renderString(
+          '''
+<% if show %>
+<% shout greeting %>
+<% endif %>
+''',
+          {'show': true, 'greeting': 'welcome'},
+        );
+        expect(result, contains('WELCOME'));
+      });
+    });
+  });
+}

--- a/pkgs/liquify_flutter/example/ios/Flutter/flutter_export_environment.sh
+++ b/pkgs/liquify_flutter/example/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/home/kingwill101/fvm/versions/3.38.3"
+export "FLUTTER_APPLICATION_PATH=/run/media/kingwill101/disk2/code/code/dart_packages/liquid_grammar/pkgs/liquify_flutter/example"
+export "COCOAPODS_PARALLEL_CODE_SIGN=true"
+export "FLUTTER_TARGET=lib/main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "FLUTTER_BUILD_NAME=1.0.0"
+export "FLUTTER_BUILD_NUMBER=1"
+export "DART_OBFUSCATION=false"
+export "TRACK_WIDGET_CREATION=true"
+export "TREE_SHAKE_ICONS=false"
+export "PACKAGE_CONFIG=.dart_tool/package_config.json"


### PR DESCRIPTION
## Summary

This PR introduces significant performance optimizations to the Liquify Liquid template parser, achieving **92-95% reduction in parser activations** and **7-8x faster wall-clock performance**, plus adds **custom delimiter support** for alternative template syntaxes.

## New Features

### Custom Delimiters

Configure alternative template delimiters via `LiquidConfig`:

```dart
// ERB-style delimiters
final liquid = Liquid(config: LiquidConfig.erb);
final result = liquid.renderString(
  '<% if show %>Hello, <%= name %>!<% endif %>',
  {'show': true, 'name': 'World'},
);

// Custom bracket delimiters
final liquid = Liquid.withDelimiters(
  tagStart: '[%',
  tagEnd: '%]',
  varStart: '[[',
  varEnd: ']]',
);
final result = liquid.renderString(
  '[% for item in items %][[ item ]] [% endfor %]',
  {'items': ['a', 'b', 'c']},
);
```

**Key additions:**
- `LiquidConfig` class for delimiter configuration
- `Liquid` class as main entry point for parsing with custom delimiters
- Built-in presets: `LiquidConfig.standard`, `LiquidConfig.erb`
- Custom tags automatically support configured delimiters via `createTagStart()`, `createTagEnd()`, etc.
- Parser caching per configuration for performance
- Config accessible during tag evaluation via `evaluator.context.config`

### Custom Tags with Custom Delimiters

Custom tags that re-parse content can access the config:

```dart
class BoxTag extends AbstractTag with CustomTagParser {
  @override
  dynamic evaluateWithContext(Evaluator evaluator, Buffer buffer) {
    final config = evaluator.context.config;
    final liquid = Liquid(config: config ?? LiquidConfig.standard);
    final result = liquid.renderString(innerContent, evaluator.context.all());
    buffer.write(result);
  }

  @override
  Parser parser([LiquidConfig? config]) {
    return (createTagStart(config) &
            string('box').trim() &
            createTagEnd(config) &
            // ... body parsing ...
            ).map((values) => Tag('box', []));
  }
}
```

## Performance Results

### Wall-Clock Timing (Before vs After)

| Template | Size | Before (master) | After (optimized) | Speedup |
|----------|------|-----------------|-------------------|---------|
| Tiny | 17 chars | 287 μs | 165 μs | **1.7x faster** |
| Small | 111 chars | 835 μs | 200 μs | **4.2x faster** |
| Medium | 134 chars | 836 μs | 169 μs | **4.9x faster** |
| Large | 822 chars | 3,730 μs | 507 μs | **7.4x faster** |
| XL | 1,095 chars | 4,877 μs | 657 μs | **7.4x faster** |

### Throughput

| Metric | Before (master) | After (optimized) | Improvement |
|--------|-----------------|-------------------|-------------|
| Chars/sec | 264 K | 2,261 K | **8.6x faster** |
| Templates/sec | 241 | 2,065 | **8.6x faster** |

### Parser Activations (92-95% reduction)

| Template Size | Before | After | Reduction |
|--------------|--------|-------|-----------|
| Tiny (17 chars) | 2,800 | 344 | **88%** |
| Small (50 chars) | 19,975 | 1,689 | **92%** |
| Medium (134 chars) | 21,062 | 1,451 | **93%** |
| Large (822 chars) | 130,961 | 6,827 | **95%** |
| XL (1,095 chars) | 203,806 | 9,832 | **95%** |

### Layout Analyzer Caching (~100x faster for repeated analysis)

| Scenario | Cold | Cached | Improvement |
|----------|------|--------|-------------|
| 10-level inheritance | 78ms | 0.9ms | **~100x faster** |
| Real-world 4-level layout | 2.3ms | 0.5ms | **~5x faster** |
| 100 full resolutions | - | 48ms total | 0.45ms each |
| resolvedBlocks (10k accesses) | - | 2ms | 0.2μs each |

### Filter Caching Optimizations

| Filter | Before | After | Improvement |
|--------|--------|-------|-------------|
| `where_exp` (500 items × 10 runs) | 270ms | 9ms | **30x faster** |
| `sort_natural` (500 items × 100 sorts) | 304ms | 166ms | **1.8x faster** |

**Filter optimizations include:**
- Expression parsing cache for `*_exp` filters (`where_exp`, `find_exp`, `group_by_exp`, `reject_exp`, etc.)
- RegExp caching for `sort_natural`, `truncatewords`, `strip_newlines`, `normalize_whitespace`, `number_of_words`
- Unified filter registry lookup cache (O(1) instead of iterating modules)

## Optimization Phases

### Phase 1: Lookahead-based element routing
Instead of trying all parsers in order, the `element()` parser now uses delimiter lookahead:
- `{{` or `{{-` → routes to variable parsers
- `{%` or `{%-` → routes to tag/block parsers  
- Otherwise → routes to text parser

### Phase 2: Precedence-based expression parser
Replaced flat choice parser with proper precedence chain:
- `expression()` → `logicalExpr()` → `comparisonExpr()` → `arithmeticExpr()` → `primaryTerm()`
- Each level parses once and reuses results, eliminating redundant backtracking

### Phase 3: Remove redundant .trim() from operators
Removed `.trim()` from individual operator parsers since surrounding whitespace is handled at higher levels.

### Phase 4: Pattern-based text() parser
Replaced `(varStart() | tagStart()).neg()` per-character approach with efficient pattern matching.

### Phase 5-8: Additional pattern-based optimizations
- Pattern-based `identifier()` and `memberAccess()` fast paths
- First-character routing in `primaryTerm()` to skip impossible alternatives

### Phase 9: Layout Analyzer Caching
- Template analysis caching with `_structureCache` and `_parseCache`
- Expando-based caching for `resolvedBlocks`, `inheritanceChain`, `allBlockNames`
- Nested lookup map caching for block resolution
- `clearCache()` and `invalidateTemplate()` methods for cache management

### Phase 10: Filter Caching
- Expression parsing cache for `*_exp` filters (parses once per unique expression)
- Cached RegExp patterns for string/array filters
- Unified filter registry lookup

## Breaking Changes (v1.5.0)

### TagDelimiterType Required for Variable-Style Custom Tags

Custom tags using `{{ }}` syntax must now declare their delimiter type:

```dart
class MyVariableTag extends AbstractTag with CustomTagParser {
  @override
  TagDelimiterType get delimiterType => TagDelimiterType.variable;
  
  @override
  Parser parser([LiquidConfig? config]) {
    return (createVarStart(config) & string('mytag').trim() & createVarEnd(config))
        .map((_) => Tag('mytag', []));
  }
}
```

Default is `TagDelimiterType.tag` for `{% %}` syntax.

## Bug Fixes

- Fixed hardcoded 'nav' tag check in `resolver.dart`
- Fixed `isOverride` logic in `template_analyzer.dart`
- Removed ~115 lines of dead code in layout analyzer

## New Tests

- **Custom delimiters test suite** (`test/custom_delimiters_test.dart`): 59 tests
- **Custom tags with custom delimiters** (`test/tags/custom_tag_with_custom_delimiters_test.dart`): 11 tests
- **Parser profiling test suite** (`test/profiling/parser_profiling_test.dart`)
- **Custom tag delimiter tests** (`test/tags/custom_tag_delimiter_test.dart`)
- **Layout performance benchmarks** (`test/layout/analyzer/layout_performance_benchmark_test.dart`)
- **Filter performance benchmarks** (`test/filters/filter_performance_benchmark_test.dart`)

## Documentation

- Reorganized and streamlined README
- Comprehensive dartdoc for `LiquidConfig`, `Liquid`, `LiquidTemplate`
- Updated `CustomTagParser` mixin documentation with config access examples
- Updated `AbstractTag` and `Environment` documentation
- New example: `example/custom_delimiters.dart`
- Updated example: `example/custom_tag.dart` with custom delimiter demos

## Testing

All **746 tests** pass.