### PR TITLE
fix: add word boundary checks to keyword literal parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add Liquify to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  liquify: ^1.4.3
+  liquify: ^1.5.1
 ```
 
 Basic usage:

--- a/pkgs/liquify/CHANGELOG.md
+++ b/pkgs/liquify/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.1
+
+### Bug Fixes
+- **Fix keyword word boundary parsing** - Keywords `empty`, `true`, `false`, and `nil` no longer incorrectly match prefixes of identifiers (e.g., `empty_title`, `true_value`, `false_flag`, `nil_check` now correctly parse as identifiers)
+
 ## 1.5.0
 
 ### New Features

--- a/pkgs/liquify/README.md
+++ b/pkgs/liquify/README.md
@@ -32,7 +32,7 @@ Add Liquify to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  liquify: ^1.5.0
+  liquify: ^1.5.1
 ```
 
 Then run `dart pub get` or `flutter pub get`.

--- a/pkgs/liquify/lib/src/grammar/shared.dart
+++ b/pkgs/liquify/lib/src/grammar/shared.dart
@@ -360,15 +360,18 @@ Parser<Literal> stringLiteral() {
 }
 
 Parser<Literal> booleanLiteral() {
-  return (string('true') | string('false'))
+  final wordBoundary = pattern('a-zA-Z0-9_-').not();
+  return ((string('true') | string('false')) & wordBoundary.and())
       .map((value) {
-        return Literal(value == 'true', LiteralType.boolean);
+        final keyword = value[0] as String;
+        return Literal(keyword == 'true', LiteralType.boolean);
       })
       .labeled('booleanLiteral');
 }
 
 Parser<Literal> nilLiteral() {
-  return (string('nil'))
+  final wordBoundary = pattern('a-zA-Z0-9_-').not();
+  return (string('nil') & wordBoundary.and())
       .map((value) {
         return Literal(null, LiteralType.nil);
       })
@@ -376,7 +379,8 @@ Parser<Literal> nilLiteral() {
 }
 
 Parser emptyLiteral() {
-  return (string('empty'))
+  final wordBoundary = pattern('a-zA-Z0-9_-').not();
+  return (string('empty') & wordBoundary.and())
       .map((value) {
         return Literal('empty', LiteralType.empty);
       })

--- a/pkgs/liquify/pubspec.yaml
+++ b/pkgs/liquify/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   A powerful and extensible Liquid template engine for Dart.
   Supports full Liquid syntax, custom tags and filters, and high-performance parsing and rendering.
 
-version: 1.5.0
+version: 1.5.1
 
 repository: https://github.com/kingwill101/liquify
 

--- a/pkgs/liquify/test/grammar_test.dart
+++ b/pkgs/liquify/test/grammar_test.dart
@@ -1243,5 +1243,84 @@ void main() {
         });
       },
     );
+
+    group('Keyword Word Boundary Regression Tests', () {
+      // These tests ensure keywords like 'empty', 'true', 'false', 'nil'
+      // don't incorrectly match the prefix of identifiers.
+      // For example, 'empty_title' should parse as an identifier, not 'empty' + '_title'
+
+      test('empty_title parses as identifier, not empty keyword', () {
+        testParser('{{ empty_title }}', (document) {
+          expect(document.children.length, 1);
+          final variable = document.children[0] as Variable;
+          expect(variable.expression, isA<Identifier>());
+          expect((variable.expression as Identifier).name, 'empty_title');
+        });
+      });
+
+      test('true_value parses as identifier, not true keyword', () {
+        testParser('{{ true_value }}', (document) {
+          expect(document.children.length, 1);
+          final variable = document.children[0] as Variable;
+          expect(variable.expression, isA<Identifier>());
+          expect((variable.expression as Identifier).name, 'true_value');
+        });
+      });
+
+      test('false_flag parses as identifier, not false keyword', () {
+        testParser('{{ false_flag }}', (document) {
+          expect(document.children.length, 1);
+          final variable = document.children[0] as Variable;
+          expect(variable.expression, isA<Identifier>());
+          expect((variable.expression as Identifier).name, 'false_flag');
+        });
+      });
+
+      test('nil_check parses as identifier, not nil keyword', () {
+        testParser('{{ nil_check }}', (document) {
+          expect(document.children.length, 1);
+          final variable = document.children[0] as Variable;
+          expect(variable.expression, isA<Identifier>());
+          expect((variable.expression as Identifier).name, 'nil_check');
+        });
+      });
+
+      test('actual empty keyword still works', () {
+        testParser('{% if items == empty %}empty{% endif %}', (document) {
+          expect(document.children.length, 1);
+          final ifTag = document.children[0] as Tag;
+          final comparison = ifTag.content[0] as BinaryOperation;
+          expect(comparison.right, isA<Literal>());
+          expect((comparison.right as Literal).type, LiteralType.empty);
+        });
+      });
+
+      test('actual true keyword still works', () {
+        testParser('{{ true }}', (document) {
+          expect(document.children.length, 1);
+          final variable = document.children[0] as Variable;
+          expect(variable.expression, isA<Literal>());
+          expect((variable.expression as Literal).value, true);
+        });
+      });
+
+      test('actual false keyword still works', () {
+        testParser('{{ false }}', (document) {
+          expect(document.children.length, 1);
+          final variable = document.children[0] as Variable;
+          expect(variable.expression, isA<Literal>());
+          expect((variable.expression as Literal).value, false);
+        });
+      });
+
+      test('actual nil keyword still works', () {
+        testParser('{{ nil }}', (document) {
+          expect(document.children.length, 1);
+          final variable = document.children[0] as Variable;
+          expect(variable.expression, isA<Literal>());
+          expect((variable.expression as Literal).type, LiteralType.nil);
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Keywords (`empty`, `true`, `false`, `nil`) no longer incorrectly match prefixes of identifiers.

## Problem

Variables like `empty_title`, `true_value`, `false_flag`, `nil_check` were failing to parse because the keyword parsers would match the prefix (e.g., `empty` from `empty_title`) and leave the suffix `_title` unparsed, causing a parsing error.

## Solution

Added negative lookahead (`pattern('a-zA-Z0-9_-').not().and()`) to keyword literal parsers to ensure keywords are only matched when not followed by identifier characters:

- `booleanLiteral()` - `true` and `false`
- `nilLiteral()` - `nil`
- `emptyLiteral()` - `empty`

## Changes

- `pkgs/liquify/lib/src/grammar/shared.dart` - Add word boundary checks
- `pkgs/liquify/test/grammar_test.dart` - Add regression tests
- `pkgs/liquify/CHANGELOG.md` - Document fix
- `pkgs/liquify/pubspec.yaml` - Bump to 1.5.1
- `pkgs/liquify/README.md` - Update version
- `README.md` - Update version

## Testing

All 65 grammar tests pass, including 8 new regression tests verifying:
- `empty_title`, `true_value`, `false_flag`, `nil_check` parse as identifiers
- Actual keywords `empty`, `true`, `false`, `nil` still work correctly